### PR TITLE
Site associate disassociate bug

### DIFF
--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -251,29 +251,8 @@ class Sites(object):
             payload_json["geolocation"] = geolocation
         return payload_json
 
-    def _build_site_device_payload(self, site_id, device_type, device_id):
-        """HTTP payload for device in a site
-
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
-        :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
-        :type device_type: str
-        :param device_id: Aruba device serial number
-        :type device_id: str
-        :return: HTTP payload for device in a site
-        :rtype: dict
-        """
-        payload_json = {
-            "site_id": site_id,
-            "device_type": device_type,
-            "device_id": device_id
-        }
-
-        return payload_json
-
     def _build_site_devices_payload(self, site_id, device_type, device_ids):
-        """HTTP payload for devices in a site
+        """HTTP payload for device(s) in a site
 
         :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
             from find_site_id function.

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -144,27 +144,6 @@ class Sites(object):
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
 
-    def associate_device(self, conn, site_id, device_type, device_id):
-        """Associate a device to a site
-
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
-        :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
-        :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
-        :type device_type: str
-        :param device_id: Aruba device serial number
-        :type device_id: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
-        :rtype: dict
-        """
-        path = None
-        path = urls.SITES["ADD_DEVICE"]
-        data = self._build_site_device_payload(site_id=site_id, device_type=device_type,
-                                               device_id=device_id)
-        resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
-        return resp
     
     def associate_devices(self, conn, site_id, device_type, device_ids):
         """Associate multiple devices to a site

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -167,30 +167,6 @@ class Sites(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def unassociate_device(self, conn, site_id, device_type, device_id):
-        """Unassociate a device from a site
-
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
-        :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
-        :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
-        :type device_type: str
-        :param device_id: Aruba device serial number
-        :type device_id: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
-        :rtype: dict
-        """
-        path = None
-        if isinstance(device_id, str):
-            path = urls.SITES["DELETE_DEVICE"]
-        else:
-            path = urls.SITES["DELETE_DEVICES"]
-        data = self._build_site_device_payload(site_id=site_id, device_type=device_type,
-                                               device_id=device_id)
-        resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
-        return resp
     
     def unassociate_devices(self, conn, site_id, device_type, device_ids):
         """Unassociate a device from a site

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -144,7 +144,7 @@ class Sites(object):
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
 
-    def associate_devices(self, conn, site_id, device_type, device_id):
+    def associate_device(self, conn, site_id, device_type, device_id):
         """Associate a device to a site
 
         :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
@@ -160,13 +160,12 @@ class Sites(object):
         :rtype: dict
         """
         path = None
-        if isinstance(device_id, str):
-            path = urls.SITES["ADD_DEVICE"]
-        else:
-            path = urls.SITES["ADD_DEVICES"]
-
+        path = urls.SITES["ADD_DEVICE"]
         data = self._build_site_device_payload(site_id=site_id, device_type=device_type,
                                                device_id=device_id)
+        resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
+        return resp
+    
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -166,6 +166,25 @@ class Sites(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
     
+    def associate_devices(self, conn, site_id, device_type, device_ids):
+        """Associate multiple devices to a site
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :type conn: class:`pycentral.ArubaCentralBase`
+        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
+            from find_site_id function.
+        :type site_id: int
+        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :type device_type: str
+        :param device_ids: List of Aruba devices' serial number
+        :type device_ids: list
+        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :rtype: dict
+        """
+        path = None
+        path = urls.SITES["ADD_DEVICES"]
+        data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
+                                               device_ids=device_ids)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -160,8 +160,10 @@ class Sites(object):
         :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = None
         path = urls.SITES["ADD_DEVICES"]
+        if isinstance(device_ids, str):
+            device_ids = [device_ids]
+    
         data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
                                                device_ids=device_ids)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
@@ -183,8 +185,10 @@ class Sites(object):
         :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = None
         path = urls.SITES["DELETE_DEVICES"]
+        if isinstance(device_ids, str):
+            device_ids = [device_ids]
+            
         data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
                                                device_ids=device_ids)
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -212,6 +212,28 @@ class Sites(object):
                                                device_id=device_id)
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
+    
+    def unassociate_devices(self, conn, site_id, device_type, device_ids):
+        """Unassociate a device from a site
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :type conn: class:`pycentral.ArubaCentralBase`
+        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
+            from find_site_id function.
+        :type site_id: int
+        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :type device_type: str
+        :param device_id: Aruba device serial number
+        :type device_id: str
+        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :rtype: dict
+        """
+        path = None
+        path = urls.SITES["DELETE_DEVICES"]
+        data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
+                                               device_ids=device_ids)
+        resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
+        return resp
 
     def find_site_id(self, conn, site_name):
         """Find site id from site name

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -188,7 +188,7 @@ class Sites(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def unassociate_devices(self, conn, site_id, device_type, device_id):
+    def unassociate_device(self, conn, site_id, device_type, device_id):
         """Unassociate a device from a site
 
         :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -275,3 +275,23 @@ class Sites(object):
         }
 
         return payload_json
+
+    def _build_site_devices_payload(self, site_id, device_type, device_ids):
+        """HTTP payload for devices in a site
+
+        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
+            from find_site_id function.
+        :type site_id: int
+        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :type device_type: str
+        :param device_ids: List of Aruba devices' serial number
+        :type device_ids: list
+        :return: HTTP payload for devices in a site
+        :rtype: dict
+        """
+        payload_json = {
+            "site_id": site_id,
+            "device_type": device_type,
+            "device_ids": device_ids
+        }
+        return payload_json

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as fh:
 
 setuptools.setup(
     name="pycentral",
-    version="0.0.2",
+    version="0.0.3",
     author="aruba-automation",
     author_email="aruba-automation@hpe.com",
     description="Aruba Central Python Package",


### PR DESCRIPTION
Simplified `associate_devices` and `unassociate_devices` to use just Device associate APIs for list of devices