### PR TITLE
Licensing api bugs

### DIFF
--- a/pycentral/licensing.py
+++ b/pycentral/licensing.py
@@ -205,12 +205,12 @@ class Subscriptions(object):
         """
         path = urls.SUBSCRIPTIONS["ASSIGN_LIC_MSP"]
         data = {
-                "services": services
+            "services": services
         }
         if include_customers:
-            data["params"]["include_customers"] = include_customers
+            data["include_customers"] = include_customers
         if exclude_customers:
-            data["params"]["exclude_customers"] = exclude_customers
+            data["exclude_customers"] = exclude_customers
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
@@ -237,12 +237,12 @@ class Subscriptions(object):
         """
         path = urls.SUBSCRIPTIONS["UNASSIGN_LIC_MSP"]
         data = {
-                "services": services
+            "services": services
         }
         if include_customers:
-            data["params"]["include_customers"] = include_customers
+            data["include_customers"] = include_customers
         if exclude_customers:
-            data["params"]["exclude_customers"] = exclude_customers
+            data["exclude_customers"] = exclude_customers
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
 
@@ -319,12 +319,12 @@ class AutoLicense(object):
         """
         path = urls.AUTO_LICENSE["DISABLE_LIC_SVC_MSP"]
         data = {
-                "services": services
+            "services": services
         }
         if include_customers:
-            data["params"]["include_customers"] = include_customers
+            data["include_customers"] = include_customers
         if exclude_customers:
-            data["params"]["exclude_customers"] = exclude_customers
+            data["exclude_customers"] = exclude_customers
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
 
@@ -370,12 +370,12 @@ class AutoLicense(object):
         """
         path = urls.AUTO_LICENSE["ASSIGN_LIC_SVC_MSP"]
         data = {
-                "services": services
+            "services": services
         }
         if include_customers:
-            data["params"]["include_customers"] = include_customers
+            data["include_customers"] = include_customers
         if exclude_customers:
-            data["params"]["exclude_customers"] = exclude_customers
+            data["exclude_customers"] = exclude_customers
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 


### PR DESCRIPTION
The "params" variable was part of the API body for several Licensing APIs. 
The current API body's of these APIs do not have "params" key. So it has been removed.

Changes were made to the following functions in the licensing module
1. assign_msp_subscription_all
2. unassign_msp_subscription_all
3. disable_msp_autolicense_services
4. assign_msp_autolicense_services