### PR TITLE
Merging dev with master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as fh:
 
 setuptools.setup(
     name="pycentral",
-    version="0.0.3",
+    version="0.0.4",
     author="aruba-automation",
     author_email="aruba-automation@hpe.com",
     description="Aruba Central Python Package",


### PR DESCRIPTION
The "params" variable was part of the API body for several Licensing APIs. Although the API calls still work with the "params" key, it's no longer publicly documented, so it could get deprecated and then cause issues. The current publicly documented API body's of these APIs do not have "params" key. So it has been removed.

Changes were made to the following functions in the licensing module
1. assign_msp_subscription_all
2. unassign_msp_subscription_all
3. disable_msp_autolicense_services
4. assign_msp_autolicense_services