### PR TITLE
Enhancements for CLI AP modules

### DIFF
--- a/pycentral/configuration.py
+++ b/pycentral/configuration.py
@@ -813,6 +813,48 @@ class ApSettings(object):
         return resp
 
 
+class APConfiguration(object):
+    """
+    A python class to manage Aruba Central access points.
+    """
+
+    def get_ap_config(self, conn, group_name):
+        """
+        Get whole configuration in CLI format of an UI group or AOS10 device.
+
+        :param group_name: Central group name or AOS10 AP serial number.
+        :type group_name: str
+
+        :return: Response as provided by 'command' function in class:
+            `pycentral.ArubaCentralBase`.
+        :rtype: dict
+        """
+        path = urlJoin(urls.AP_CONFIGURATION["GET"], group_name)
+        resp = conn.command(apiMethod="GET", apiPath=path)
+
+        return resp
+
+    def replace_ap(self, conn, group_name, data):
+        """
+        Replace whole configuration for a Central UI group or AOS10 device.
+        Configuration is in CLI format.
+
+        :param group_name: Central group name or AOS10 AP serial number.
+        :type group_name: str
+        :param data: AP CLI configuration commands. Format for json value
+            is a list of CLI command strings.
+        :type data: json
+
+        :return: Response as provided by 'command' function in class:
+            `pycentral.ArubaCentralBase`.
+        :rtype: dict
+        """
+        path = urlJoin(urls.AP_CONFIGURATION["REPLACE"], group_name)
+        resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
+
+        return resp
+
+
 class Wlan(object):
     """A python class consisting of functions to manage Aruba Central WLANs
     via REST API.

--- a/pycentral/configuration.py
+++ b/pycentral/configuration.py
@@ -813,7 +813,7 @@ class ApSettings(object):
         return resp
 
 
-class APConfiguration(object):
+class ApConfiguration(object):
     """
     A python class to manage Aruba Central access points with API's from
     the AP configuration category.

--- a/pycentral/configuration.py
+++ b/pycentral/configuration.py
@@ -815,7 +815,8 @@ class ApSettings(object):
 
 class APConfiguration(object):
     """
-    A python class to manage Aruba Central access points.
+    A python class to manage Aruba Central access points with API's from
+    the AP configuration category.
     """
 
     def get_ap_config(self, conn, group_name):

--- a/pycentral/url_utils.py
+++ b/pycentral/url_utils.py
@@ -38,7 +38,7 @@ class ConfigurationUrl():
 
     AP_CONFIGURATION = {
         "GET": "/configuration/v1/ap_cli",
-        "REPLACE": "/configuration/v1/ap_settings_cli"
+        "REPLACE": "/configuration/v1/ap_cli"
     }
 
     GROUPS = {

--- a/pycentral/url_utils.py
+++ b/pycentral/url_utils.py
@@ -29,10 +29,16 @@ class RefreshUrl(object):
         "REFRESH": "/oauth2/token"
     }
 
+
 class ConfigurationUrl():
     AP_SETTINGS = {
         "GET": "/configuration/v2/ap_settings",
         "UPDATE": "/configuration/v2/ap_settings"
+    }
+
+    AP_CONFIGURATION = {
+        "GET": "/configuration/v1/ap_cli",
+        "REPLACE": "/configuration/v1/ap_settings_cli"
     }
 
     GROUPS = {


### PR DESCRIPTION
Enhancements for CLI AP modules.  Includes new classes named after the API reference categories where the API's are stored.

Added ApConfiguration class to configuration.py for housing ApConfiguration category modules.

- get_ap_configuration to pull full CLI configuration of an Aruba Central group
- replace_ap to completely replace an AP config with a new CLI config

Added AP_CONFIGURATION dictionary to url_utils for url path endpoints.

- Get endpoint
- Replace endpoint
