### PR TITLE
Style linting pycentral modules

### DIFF
--- a/pycentral/audit_logs.py
+++ b/pycentral/audit_logs.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,52 +22,60 @@
 
 from pycentral.url_utils import AuditUrl, urlJoin
 from pycentral.base_utils import console_logger
+
 urls = AuditUrl()
 
-class Audit():
-    """Get the audit logs and event logs with the functions in this class.
-    """
-    def get_traillogs(self, conn, limit=100, offset=0, username=None, start_time=None,
-                      end_time=None, description=None, target=None, classification=None,
-                      customer_name=None, ip_address=None, app_id=None):
-        """Get audit logs, sort by time in in reverse chronological order. This API returns the first 10,000
-        results only. Please use filter in the API for more relevant results. MSP Customer Would see logs of MSP's
-        and tenants as well.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+class Audit:
+    """Get the audit logs and event logs with the functions in this class."""
+
+    def get_traillogs(self, conn, limit=100, offset=0, username=None,
+                      start_time=None, end_time=None, description=None,
+                      target=None, classification=None, customer_name=None,
+                      ip_address=None, app_id=None):
+        """Get audit logs, sort by time in in reverse chronological order.
+        This API returns the first 10,000 results only. Please use filter
+        in the API for more relevant results. MSP Customer Would see logs
+        of MSP's and tenants as well.
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param limit: Maximum number of audit events to be returned, defaults to 100
+        :param limit: Maximum number of audit events to be returned, defaults\
+            to 100
         :type limit: int, optional
-        :param offset: Number of items to be skipped before returning the data, useful for pagination, defaults to 0
+        :param offset: Number of items to be skipped before returning the \
+            data, useful for pagination, defaults to 0
         :type offset: int, optional
         :param username: Filter audit logs by User Name, defaults to None
         :type username: str, optional
-        :param start_time: Filter audit logs by Time Range. Start time of the audit logs should be provided in epoch
-            seconds, defaults to None
+        :param start_time: Filter audit logs by Time Range. Start time of the\
+            audit logs should be provided in epoch seconds, defaults to None
         :type start_time: int, optional
-        :param end_time: Filter audit logs by Time Range. End time of the audit logs should be provided in epoch
-            seconds, defaults to None
+        :param end_time: Filter audit logs by Time Range. End time of the \
+            audit logs should be provided in epoch seconds, defaults to None
         :type end_time: int, optional
-        :param description: Filter audit logs by Description, defaults to None
+        :param description: Filter audit logs by Description, defaults to \
+            None
         :type description: str, optional
         :param target: Filter audit logs by target, defaults to None
         :type target: str, optional
-        :param classification: Filter audit logs by Classification, defaults to None
+        :param classification: Filter audit logs by Classification, defaults \
+            to None
         :type classification: str, optional
-        :param customer_name: Filter audit logs by Customer NameFilter audit logs by Customer Name, defaults to None
+        :param customer_name: Filter audit logs by Customer NameFilter audit \
+            logs by Customer Name, defaults to None
         :type customer_name: str, optional
         :param ip_address: Filter audit logs by IP Address, defaults to None
         :type ip_address: str, optional
         :param app_id: Filter audit logs by app_id, defaults to None
         :type app_id: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in \
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.TRAIL_LOG["GET_ALL"]
-        params = {
-            "limit": limit,
-            "offset": offset
-        }
+        params = {"limit": limit, "offset": offset}
         if username:
             params["username"] = username
         if start_time:
@@ -92,49 +100,58 @@ class Audit():
     def get_traillogs_detail(self, conn, id):
         """Get details of an audit log
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param id: ID of audit event
         :type id: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in \
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TRAIL_LOG["GET"], id)
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
-    def get_eventlogs(self, conn, limit=100, offset=0, group_name=None, device_id=None,
-                      classification=None, start_time=None, end_time=None):
-        """Get audit events for all groups, sort by time in in reverse chronological order.This API returns the
-        first 10,000 results only. Please use filter in the API for more relevant results.
+    def get_eventlogs(self, conn, limit=100, offset=0, group_name=None,
+                      device_id=None, classification=None, start_time=None,
+                      end_time=None):
+        """Get audit events for all groups, sort by time in in reverse\
+            chronological order.This API returns the first 10,000 results\
+            only. Please use filter in the API for more relevant results.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param limit: Maximum number of audit events to be returned, defaults to 100
+        :param limit: Maximum number of audit events to be returned, defaults\
+            to 100
         :type limit: int, optional
-        :param offset: Number of items to be skipped before returning the data, useful for pagination, defaults to 0
+        :param offset: Number of items to be skipped before returning the\
+            data, useful for pagination, defaults to 0
         :type offset: int, optional
         :param group_name: Filter audit events by Group Name, defaults to None
         :type group_name: str, optional
-        :param device_id: Filter audit events by Target / Device ID. Device ID for AP is VC Name and Serial Number
+        :param device_id: Filter audit events by Target / Device ID. Device ID\
+            for AP is VC Name and Serial Number
             for Switches, defaults to None
         :type device_id: str, optional
-        :param classification: Filter audit events by classification, defaults to None
+        :param classification: Filter audit events by classification, defaults\
+            to None
         :type classification: str, optional
-        :param start_time: Filter audit logs by Time Range. Start time of the audit logs should be provided
+        :param start_time: Filter audit logs by Time Range. Start time of the\
+            audit logs should be provided
             in epoch seconds, defaults to None
         :type start_time: int, optional
-        :param end_time: Filter audit logs by Time Range. End time of the audit logs should be provided in epoch
+        :param end_time: Filter audit logs by Time Range. End time of the\
+            audit logs should be provided in epoch
             seconds, defaults to None
         :type end_time: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.EVENT_LOG["GET_ALL"]
-        params = {
-            "limit": limit,
-            "offset": offset
-        }
+        params = {"limit": limit, "offset": offset}
         if group_name:
             params["group_name"] = group_name
         if device_id:
@@ -151,11 +168,13 @@ class Audit():
     def get_eventlogs_detail(self, conn, id):
         """Get details of an audit event/log
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param id: ID of audit event
         :type id: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.EVENT_LOG["GET"], id)

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -20,7 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import json, re, os, sys, time
+import json
+import re
+import os
+import sys
+import time
 import requests
 import errno
 from pycentral.base_utils import tokenLocalStoreUtil
@@ -29,6 +33,7 @@ from pycentral.base_utils import console_logger, parseInputArgs
 
 SUPPORTED_METHODS = ("POST", "PATCH", "DELETE", "GET", "PUT")
 
+
 class BearerAuth(requests.auth.AuthBase):
     """This class uses Bearer Auth method to generate the authorization header
     from Aruba Central Access Token.
@@ -36,48 +41,66 @@ class BearerAuth(requests.auth.AuthBase):
     :param token: Aruba Central Access Token
     :type token: str
     """
+
     def __init__(self, token):
-        """Constructor Method
-        """
+        """Constructor Method"""
         self.token = token
+
     def __call__(self, r):
-        """Internal method returning auth
-        """
+        """Internal method returning auth"""
         r.headers["authorization"] = "Bearer " + self.token
         return r
 
-class ArubaCentralBase:
-    """This is the Base class for Aruba Central which handles.
-    1. token management (OAUTH2.0, cache/storage for reuse and refresh token). Default token caching
-    is in unencrypted file. Override with your implementation for secure handling of access tokens.
-    2. command function makes API requests, handles token expiry and auto-refresh expired tokens.
-    Auto-refreh feature is functional only when OAUTH2.0 is provided. Otherwise, refresh expired tokens at your convenience.
 
-    :param central_info: Containing information related Aruba Central and API Gateway for HTTPS connection. \n
-        * keyword username: (Optional) Aruba Central username string. Provide for OAUTH2.0 if access token is not provided. \n
-        * keyword password: (Optional) Aruba Central password string. Provide for OAUTH2.0 if access token is not provided. \n
-        * keyword client_id: (Optional) API Gateway client_id string, Provide for OAUTH2.0 and refresh token API. \n
-        * keyword client_secret: (Optional) API Gateway client_secret string, Provide for OAUTH2.0 and refresh token API. \n
-        * keyword customer_id: (Optional) API Gateway client_secret string, Provide for OAUTH2.0 and refresh token API. \n
-        * keyword base_url: Provide the API Gateway string base FQDN in format https://<Aruba-Central-API-Gateway-Domain-Name> \n
-        * keyword token: (Optional) The token dict is mutually excluive with OAUTH2.0 parameters. token dict should consist of \
-        the following key-value pairs {"access_token": "xxxx", "refresh_token": "XXYY"} \n
+class ArubaCentralBase:
+    """This is the Base class for Aruba Central which handles - \n
+    1. token management (OAUTH2.0, cache/storage for reuse and refresh token).\
+        Default token caching is in unencrypted file. Override with your\
+        implementation for secure handling of access tokens.
+    2. command function makes API requests, handles token expiry and\
+        auto-refresh expired tokens. Auto-refresh feature is functional only\
+        when OAUTH2.0 is provided. Otherwise, refresh expired tokens at your\
+        convenience.
+
+    :param central_info: Containing information related Aruba Central and API\
+        Gateway for HTTPS connection. \n
+        * keyword username: (Optional) Aruba Central username string. Provide\
+            for OAUTH2.0 if access token is not provided. \n
+        * keyword password: (Optional) Aruba Central password string. Provide\
+            for OAUTH2.0 if access token is not provided. \n
+        * keyword client_id: (Optional) API Gateway client_id string, Provide\
+            for OAUTH2.0 and refresh token API. \n
+        * keyword client_secret: (Optional) API Gateway client_secret string,\
+            Provide for OAUTH2.0 and refresh token API. \n
+        * keyword customer_id: (Optional) API Gateway client_secret string,\
+            Provide for OAUTH2.0 and refresh token API. \n
+        * keyword base_url: Provide the API Gateway string base FQDN in format\
+            `https://<Aruba-Central-API-Gateway-Domain-Name>` \n
+        * keyword token: (Optional) The token dict is mutually excluive with\
+            OAUTH2.0 parameters. token dict should consist of the following\
+            key-value pairs - \n
+                {"access_token": "xxxx", "refresh_token": "XXYY"}\n
     :type central_info: dict
-    :param token_store: Placeholder for future development which provides options to secrely cache and \
-        reuse access tokens. defaults to None
+    :param token_store: Placeholder for future development which provides\
+        options to secrely cache and reuse access tokens. defaults to None
     :type token_store: dict, optional
-    :param user_retries: Number of times API call should be retried after a rate-limit error HTTP 429 occurs.
+    :param user_retries: Number of times API call should be retried after a\
+        rate-limit error HTTP 429 occurs.
     :type user_retries: int, optional
-    :param logger: Provide an instance of class:`logging.logger`, defaults to logger class with name "ARUBA_BASE".
+    :param logger: Provide an instance of class:`logging.logger`, defaults to\
+        logger class with name "ARUBA_BASE".
     :type logger: class:`logging.logger`, optional
-    :param ssl_verify: When set to True, validates SSL certs of Aruba Central API Gateway, defaults to True
+    :param ssl_verify: When set to True, validates SSL certs of Aruba Central\
+        API Gateway, defaults to True
     :type ssl_verify: bool, optional
     """
-    def __init__(self, central_info, token_store=None,
-                 logger=None, ssl_verify=True, user_retries=10):
-        """Constructor Method initializes access token. If user provides access token, use the access
-        token for API calls. Otherwise try to reuse token from cache or try to generate
-        new access token via OAUTH 2.0. Terminates the program if unable to initialize the access token.
+
+    def __init__(self, central_info, token_store=None, logger=None,
+                 ssl_verify=True, user_retries=10):
+        """Constructor Method initializes access token. If user provides\
+        access token, use the access token for API calls. Otherwise try to\
+        reuse token from cache or try to generate new access token via OAUTH\
+        2.0. Terminates the program if unable to initialize the access token.
         """
         self.central_info = parseInputArgs(central_info)
         self.token_store = token_store
@@ -100,48 +123,56 @@ class ArubaCentralBase:
             sys.exit("exiting.. unable to get API access token!")
 
     def oauthLogin(self):
-        """This function is Step1 of the OAUTH2.0 mechanism to generate access token. Login to Aruba Central
+        """This function is Step1 of the OAUTH2.0 mechanism to generate access\
+            token. Login to Aruba Central
         is performed using username and password.
 
         :return: Tuple with two strings, csrf token and login session key.
         :rtype: tuple
         """
-        headers = {'Content-Type': 'application/json'}
+        headers = {"Content-Type": "application/json"}
 
         path = "/oauth2/authorize/central/api/login"
-        query = {
-            "client_id": self.central_info["client_id"]
-        }
-        url = get_url(base_url=self.central_info["base_url"],
-                      path=path, query=query)
+        query = {"client_id": self.central_info["client_id"]}
+        url = get_url(
+            base_url=self.central_info["base_url"], path=path, query=query)
 
-        data = json.dumps({"username": self.central_info["username"],
-                           "password": self.central_info["password"]})
+        data = json.dumps(
+            {
+                "username": self.central_info["username"],
+                "password": self.central_info["password"],
+            }
+        )
         data = data.encode("utf-8")
         try:
             s = requests.Session()
-            req = requests.Request(method="POST", url=url, data=data,
-                                   headers=headers)
+            req = requests.Request(
+                method="POST", url=url, data=data, headers=headers)
             prepped = s.prepare_request(req)
-            settings = s.merge_environment_settings(prepped.url, {},
-                                                    None, self.ssl_verify, None)
+            settings = s.merge_environment_settings(
+                prepped.url, {}, None, self.ssl_verify, None
+            )
             resp = s.send(prepped, **settings)
             if resp and resp.status_code == 200:
                 cookies = resp.cookies.get_dict()
-                return cookies['csrftoken'], cookies['session']
+                return cookies["csrftoken"], cookies["session"]
             else:
                 resp_msg = {
-                                "code": resp.status_code,
-                                "msg": resp.text
-                            }
-                self.logger.error("OAUTH2.0 Step1 login API call failed with response " + str(resp_msg))
+                    "code": resp.status_code,
+                    "msg": resp.text
+                }
+                self.logger.error(
+                    "OAUTH2.0 Step1 login API call failed with response "
+                    + str(resp_msg)
+                )
                 sys.exit(1)
         except Exception as e:
             self.logger.error("OAUTH2.0 Step1 failed with error " + str(e))
             sys.exit(1)
 
     def oauthCode(self, csrf_token, session_token):
-        """This function is Step2 of the OAUTH2.0 mechanism to get auth code using CSRF token and session key.
+        """This function is Step2 of the OAUTH2.0 mechanism to get auth code\
+            using CSRF token and session key.
 
         :param csrf_token: CSRF token obtained from Step1 of OAUTH2.0
         :type csrf_token: str
@@ -157,86 +188,103 @@ class ArubaCentralBase:
             "response_type": "code",
             "scope": "all"
         }
-        url = get_url(base_url=self.central_info["base_url"],
-                      path=path, query=query)
+        url = get_url(
+            base_url=self.central_info["base_url"], path=path, query=query)
 
         customer_id = self.central_info["customer_id"]
-        data = json.dumps({'customer_id': customer_id}).encode("utf-8")
-        headers = {'X-CSRF-TOKEN': csrf_token,
-                    'Content-Type': 'application/json',
-                    'Cookie': "session="+session_token}
+        data = json.dumps({"customer_id": customer_id}).encode("utf-8")
+        headers = {
+            "X-CSRF-TOKEN": csrf_token,
+            "Content-Type": "application/json",
+            "Cookie": "session=" + session_token
+        }
         try:
             s = requests.Session()
-            req = requests.Request(method="POST", url=url, data=data,
-                                   headers=headers)
+            req = requests.Request(
+                method="POST", url=url, data=data, headers=headers)
             prepped = s.prepare_request(req)
-            settings = s.merge_environment_settings(prepped.url, {},
-                                                    None, self.ssl_verify, None)
+            settings = s.merge_environment_settings(
+                prepped.url, {}, None, self.ssl_verify, None
+            )
             resp = s.send(prepped, **settings)
             if resp and resp.status_code == 200:
                 result = json.loads(resp.text)
-                auth_code = result['auth_code']
+                auth_code = result["auth_code"]
                 return auth_code
             else:
-                resp_msg = {
-                                "code": resp.status_code,
-                                "msg": resp.text
-                            }
-                self.logger.error("OAUTH2.0 Step2 obtaining Auth code API call failed with response " + str(resp_msg))
+                resp_msg = {"code": resp.status_code, "msg": resp.text}
+                self.logger.error(
+                    "OAUTH2.0 Step2 obtaining Auth code API call failed with\
+                        response " + str(resp_msg)
+                )
                 sys.exit(1)
         except Exception as e:
-            self.logger.error("Central Login Step2 failed with error " + str(e))
+            self.logger.error(
+                "Central Login Step2 failed with error " + str(e))
             sys.exit(1)
 
     def oauthAccessToken(self, auth_code):
-        """This function is Step3 of the OAUTH2.0 mechanism to generate API access token.
+        """This function is Step3 of the OAUTH2.0 mechanism to generate API\
+            access token.
 
         :param auth_code: Auth code from Step2 of OAUTH2.0.
         :type auth_code: str
-        :return: token information received from API call consisting of access_token and refresh_token.
+        :return: token information received from API call consisting of\
+            access_token and refresh_token.
         :rtype: dict
         """
-        path =  "/oauth2/token"
+        path = "/oauth2/token"
         query = {
             "client_id": self.central_info["client_id"],
             "client_secret": self.central_info["client_secret"],
             "grant_type": "authorization_code",
             "code": auth_code
         }
-        url = get_url(base_url=self.central_info["base_url"],
-                      path=path, query=query)
+        url = get_url(
+            base_url=self.central_info["base_url"], path=path, query=query)
 
         try:
             s = requests.Session()
             req = requests.Request(method="POST", url=url)
             prepped = s.prepare_request(req)
-            settings = s.merge_environment_settings(prepped.url, {},
-                                                    None, self.ssl_verify, None)
+            settings = s.merge_environment_settings(
+                prepped.url, {}, None, self.ssl_verify, None
+            )
             resp = s.send(prepped, **settings)
             if resp.status_code == 200:
                 result = json.loads(resp.text)
                 token = result
                 return token
             else:
-                resp_msg = {
-                                "code": resp.status_code,
-                                "msg": resp.text
-                            }
-                self.logger.error("OAUTH2.0 Step3 creating access token API call failed with response " + str(resp_msg))
+                resp_msg = {"code": resp.status_code, "msg": resp.text}
+                self.logger.error(
+                    "OAUTH2.0 Step3 creating access token API call failed with\
+                        response "
+                    + str(resp_msg)
+                )
                 sys.exit(1)
         except Exception as e:
-            self.logger.error("Central Login Step3 failed with error " + str(e))
+            self.logger.error(
+                "Central Login Step3 failed with error " + str(e))
             sys.exit(1)
 
     def validateOauthParams(self):
-        """This function validates if all required parameters are available to obtain access_token via OAUTH2.0 mechanism
+        """This function validates if all required parameters are available to\
+            obtain access_token via OAUTH2.0 mechanism
         in Aruba Central.
 
-        :return: True when validation of availability of the required parameters passed.
+        :return: True when validation of availability of the required\
+            parameters passed.
         :rtype: bool
         """
-        oauth_keys = ["client_id", "client_secret", "customer_id",
-                      "username", "password", "base_url"]
+        oauth_keys = [
+            "client_id",
+            "client_secret",
+            "customer_id",
+            "username",
+            "password",
+            "base_url",
+        ]
         oauth_keys = set(oauth_keys)
         input_keys = set(self.central_info.keys())
         missing_keys = []
@@ -246,15 +294,19 @@ class ArubaCentralBase:
             if not self.central_info[key]:
                 missing_keys.append(key)
         if missing_keys:
-            self.logger.error("Missing input parameters "
-                              "%s required for OAuth" % str(missing_keys))
+            self.logger.error(
+                "Missing input parameters " "%s required for OAuth" %
+                str(missing_keys)
+            )
             return False
         return True
 
     def validateRefreshTokenParams(self):
-        """This function validates if all required parameters are available for refresh token API call.
+        """This function validates if all required parameters are available\
+            for refresh token API call.
 
-        :return: True when the validation of the availability of required parameters passed.
+        :return: True when the validation of the availability of required\
+            parameters passed.
         :rtype: bool
         """
         required_keys = ["base_url", "client_id", "client_secret"]
@@ -267,13 +319,16 @@ class ArubaCentralBase:
             if not self.central_info[key]:
                 missing_keys.append(key)
         if missing_keys:
-            self.logger.warning("Missing required parameters for refresh "
-                                "token %s" % str(missing_keys))
+            self.logger.warning(
+                "Missing required parameters for refresh "
+                "token %s" % str(missing_keys)
+            )
             return False
         return True
 
     def createToken(self):
-        """This function generates a new access token for Aruba Central via OAUTH2.0 APIs.
+        """This function generates a new access token for Aruba Central via\
+            OAUTH2.0 APIs.
 
         :return: The token dict conisting of access_token and refresh_token.
         :rtype: dict
@@ -294,115 +349,137 @@ class ArubaCentralBase:
         return access_token
 
     def refreshToken(self, old_token):
-        """This function refreshes the provided API Gateway token using OAUTH2.0 API. In addition to the input args,
-        this function also depends on the class variable definitions client_id and client_secret.
+        """This function refreshes the provided API Gateway token using\
+        OAUTH2.0 API. In addition to the input args, this function also\
+        depends on the class variable definitions client_id and client_secret.
 
         :param old_token: API Gateway token dict consisting of refresh_token.
         :type old_token: dict
-        :raises UserWarning: Raises warning when validation of availability of the required parameters fails.
-        :raises UserWarning: Raises warning when token input param is provided but it doesn't have refresh_token.
-        :return: Token dictionary consisting of refreshed access_token and new refresh_token.
+        :raises UserWarning: Raises warning when validation of availability of\
+            the required parameters fails.
+        :raises UserWarning: Raises warning when token input param is provided\
+            but it doesn't have refresh_token.
+        :return: Token dictionary consisting of refreshed access_token and new\
+            refresh_token.
         :rtype: dict
         """
         token = None
-        resp = ''
+        resp = ""
         try:
             if not self.validateRefreshTokenParams():
                 raise UserWarning("")
             if "refresh_token" not in old_token:
-                raise UserWarning("refresh_token not present in the input "
-                                  "token dict")
+                raise UserWarning(
+                    "refresh_token not present in the input " "token dict"
+                )
 
             path = "/oauth2/token"
             query = {
                 "client_id": self.central_info["client_id"],
                 "client_secret": self.central_info["client_secret"],
                 "grant_type": "refresh_token",
-                "refresh_token": old_token["refresh_token"]
+                "refresh_token": old_token["refresh_token"],
             }
-            url = get_url(base_url=self.central_info["base_url"],
-                          path=path, query=query)
+            url = get_url(
+                base_url=self.central_info["base_url"], path=path, query=query
+            )
 
             s = requests.Session()
             req = requests.Request(method="POST", url=url)
             prepped = s.prepare_request(req)
-            settings = s.merge_environment_settings(prepped.url, {},
-                                                    None, self.ssl_verify, None)
+            settings = s.merge_environment_settings(
+                prepped.url, {}, None, self.ssl_verify, None
+            )
             resp = s.send(prepped, **settings)
             if resp.status_code == 200:
                 token = json.loads(resp.text)
             else:
-                resp_msg = {
-                                "code": resp.status_code,
-                                "msg": resp.text
-                            }
-                self.logger.error("Refresh token API call failed with response " + str(resp_msg))
+                resp_msg = {"code": resp.status_code, "msg": resp.text}
+                self.logger.error(
+                    "Refresh token API call failed with response " +
+                    str(resp_msg)
+                )
         except Exception as err:
-            self.logger.error("Unable to refresh token.. "
-                              "%s" % str(err))
+            self.logger.error("Unable to refresh token.. " "%s" % str(err))
         return token
 
     def storeToken(self, token):
-        """This function handles storage of token for later use. Default storage is unencrypted JSON file and is not secure.
-        Override this function and loadToken function to implement secure access token caching mechanism.
+        """This function handles storage of token for later use. Default\
+        storage is unencrypted JSON file and is not secure. Override this\
+        function and loadToken function to implement secure access token\
+        caching mechanism.
 
-        :param token: API Gateway token dict consisting of access_token and refresh_token.
+        :param token: API Gateway token dict consisting of access_token and\
+            refresh_token.
         :type token: dict
         :return: True if the access_token caching is successful.
         :rtype: bool
         """
-        fullName = tokenLocalStoreUtil(self.token_store,
-                                       self.central_info["customer_id"],
-                                       self.central_info["client_id"])
+        fullName = tokenLocalStoreUtil(
+            self.token_store,
+            self.central_info["customer_id"],
+            self.central_info["client_id"]
+        )
         if not os.path.exists(os.path.dirname(fullName)):
             try:
                 os.makedirs(os.path.dirname(fullName))
             except OSError as exc:  # Guard against race condition
                 if exc.errno != errno.EEXIST:
-                    self.logger.error("Storing token failed with error "
-                                      "%s" % str(exc))
+                    self.logger.error(
+                        "Storing token failed with error " "%s" % str(exc)
+                    )
 
         # Dumping data to json file
         try:
-            with open(fullName, 'w') as fp:
+            with open(fullName, "w") as fp:
                 json.dump(token, fp, indent=2)
-            self.logger.info("Stored Aruba Central token in file " + \
-                             "%s" % str(fullName))
+            self.logger.info(
+                "Stored Aruba Central token in file " + "%s" % str(fullName)
+            )
             return True
         except Exception as err:
             self.logger.error("Storing token failed with error %s" % str(err))
         return False
 
     def loadToken(self):
-        """This function handles loading API Gateway token from cache/storage. Default token load is from local JSON file.
-        Override this function with storeToken function to implement secure access token caching mechanism.
+        """This function handles loading API Gateway token from cache/storage.\
+        Default token load is from local JSON file. Override this function\
+        with storeToken function to implement secure access token caching\
+        mechanism.
 
         :raises UserWarning: Warning to capture empty JSON
-        :return: token dict loaded from default implementation of locally stored JSON file consisting of
-            access_token and refresh_token.
+        :return: token dict loaded from default implementation of locally\
+            stored JSON file consisting of access_token and refresh_token.
         :rtype: dict
         """
-        fullName = tokenLocalStoreUtil(self.token_store,
-                                       self.central_info["customer_id"],
-                                       self.central_info["client_id"])
+        fullName = tokenLocalStoreUtil(
+            self.token_store,
+            self.central_info["customer_id"],
+            self.central_info["client_id"]
+        )
         token = None
         try:
-            with open(fullName, 'r') as fp:
+            with open(fullName, "r") as fp:
                 token = json.load(fp)
             if token:
-                self.logger.info("Loaded token from storage from file: " + \
-                                 "%s" % str(fullName))
+                self.logger.info(
+                    "Loaded token from storage from file: " +
+                    "%s" % str(fullName)
+                )
             else:
                 raise UserWarning("Empty file!")
         except Exception as err:
-            self.logger.error("Unable to load token from storage with error "
-                              ".. %s" % str(err))
+            self.logger.error(
+                "Unable to load token from storage with error " ".. %s" %
+                str(err)
+            )
         return token
 
     def handleTokenExpiry(self):
-        """This function handles 401 error as a result of HTTP request. An attempt to refresh token is made.
-        If refreshing token fails, this function tries to create new access token. Stores token for reuse.
-        If all the attemps fail, program is terminated.
+        """This function handles 401 error as a result of HTTP request.\
+        An attempt to refresh token is made. If refreshing token fails, this\
+        function tries to create new access token. Stores token for reuse. If\
+        all the attemps fail, program is terminated.
         """
         self.logger.info("Handling Token Expiry...")
         token = self.refreshToken(self.central_info["token"])
@@ -418,10 +495,11 @@ class ArubaCentralBase:
             self.logger.error("Failed to get API access token")
 
     def getToken(self):
-        """This function attempts to obtain token from storage/cache otherwise creates new access token.
-        Stores the token if new token is generated.
+        """This function attempts to obtain token from storage/cache otherwise\
+        creates new access token. Stores the token if new token is generated.
 
-        :return: API Gateway token dict consisting of access_token and refresh_token
+        :return: API Gateway token dict consisting of access_token and\
+            refresh_token
         :rtype: dict
         """
         # Check if the token is stored
@@ -430,8 +508,8 @@ class ArubaCentralBase:
             return token
         # Otherwise generate new token
         else:
-            self.logger.info("Attempting to create new token from "
-                             "Aruba Central")
+            self.logger.info(
+                "Attempting to create new token from " "Aruba Central")
             token = self.createToken()
             if token and token != "":
                 self.storeToken(token)
@@ -439,22 +517,24 @@ class ArubaCentralBase:
             self.logger.error("Unable to get API Access Token!")
         return token
 
-    def requestUrl(self, url, data={}, method="GET", headers={},
-                   params={}, files={}):
-        """This function makes API call to Aruba Central via python requests library.
+    def requestUrl(self, url, data={}, method="GET", headers={}, params={},
+                   files={}):
+        """This function makes API call to Aruba Central via python requests\
+            library.
 
         :param url: HTTP Request URL string
         :type url: string
         :param data: HTTP Request payload, defaults to {}
         :type data: dict, optional
-        :param method: HTTP Request Method supported by Aruba Central, defaults to "GET"
+        :param method: HTTP Request Method supported by Aruba Central,\
+            defaults to "GET"
         :type method: str, optional
         :param headers: HTTP Request headers, defaults to {}
         :type headers: dict, optional
         :param params: HTTP url query parameteres, defaults to {}
         :type params: dict, optional
-        :param files: files dictionary with file pointer depending on API endpoint as acceped by
-            Aruba Central, defaults to {}
+        :param files: files dictionary with file pointer depending on API\
+            endpoint as acceped by Aruba Central, defaults to {}
         :type files: dict, optional
         :return: HTTP response of API call using requests library
         :rtype: class:`requests.models.Response`
@@ -466,12 +546,19 @@ class ArubaCentralBase:
 
         auth = BearerAuth(self.central_info["token"]["access_token"])
         s = requests.Session()
-        req = requests.Request(method=method, url=url, headers=headers,
-                               files=files, auth=auth, params=params,
-                               data=data)
+        req = requests.Request(
+            method=method,
+            url=url,
+            headers=headers,
+            files=files,
+            auth=auth,
+            params=params,
+            data=data,
+        )
         prepped = s.prepare_request(req)
-        settings = s.merge_environment_settings(prepped.url, {},
-                                                None, self.ssl_verify, None)
+        settings = s.merge_environment_settings(
+            prepped.url, {}, None, self.ssl_verify, None
+        )
         try:
             resp = s.send(prepped, **settings)
             return resp
@@ -480,55 +567,71 @@ class ArubaCentralBase:
             str2 = "with error %s" % str(err)
             self.logger.error(str1 + str2)
 
-    def command(self, apiMethod, apiPath, apiData={}, apiParams={},
-                headers={}, files={}):
-        """This function calls requestURL to make an API call to Aruba Central after gathering parameters required for API call.
-        When an API call fails with HTTP 401 error code, the same API call is retried once after an attempt to refresh access token or
-        create new access token is made.
+    def command(self, apiMethod, apiPath, apiData={}, apiParams={}, headers={},
+                files={}):
+        """This function calls requestURL to make an API call to Aruba Central\
+            after gathering parameters required for API call. When an API call\
+            fails with HTTP 401 error code, the same API call is retried once\
+            after an attempt to refresh access token or create new access\
+            token is made.
 
-        :param apiMethod: HTTP Method for API call. Should be one of the supported methods for the respective Aruba Central API endpoint.
+        :param apiMethod: HTTP Method for API call. Should be one of the\
+            supported methods for the respective Aruba Central API endpoint.
         :type apiMethod: str
-        :param apiPath: Path to the API endpoint as required by API endpoint. Refer Aruba Central API reference swagger documentation.
+        :param apiPath: Path to the API endpoint as required by API endpoint.\
+            Refer Aruba Central API reference swagger documentation.
         :type apiPath: str
-        :param apiData: HTTP payload for the API call as required by API endpoint. Refer Aruba Central API reference swagger
-            documentation, defaults to {}
+        :param apiData: HTTP payload for the API call as required by API\
+            endpoint. Refer Aruba Central API reference swagger documentation,\
+            defaults to {}
         :type apiData: dict, optional
-        :param apiParams: HTTP url query parameters as required by API endpoint. Refer Aruba Central API reference
-            swagger, defaults to {}
+        :param apiParams: HTTP url query parameters as required by API\
+            endpoint. Refer Aruba Central API reference swagger, defaults to {}
         :type apiParams: dict, optional
-        :param headers: HTTP headers as required by API endpoint. Refer Aruba Central API reference swagger, defaults to {}
+        :param headers: HTTP headers as required by API endpoint. Refer Aruba\
+            Central API reference swagger, defaults to {}
         :type headers: dict, optional
-        :param files: Some API endpoints require a file upload instead of apiData. Provide file data in the format accepted by API
-            endpoint and Python requests library, defaults to {}
+        :param files: Some API endpoints require a file upload instead of\
+            apiData. Provide file data in the format accepted by API endpoint\
+            and Python requests library, defaults to {}
         :type files: dict, optional
-        :return: HTTP response with HTTP staus_code and HTTP response payload. \n
+        :return: HTTP response with HTTP status_code and HTTP response\
+            payload.\n
             * keyword code: HTTP status code \n
             * keyword msg: HTTP response payload \n
         :rtype: dict
         """
         retry = 0
-        result = ''
+        result = ""
         method = apiMethod
         limit_reached = False
         self.user_retries
         try:
             while not limit_reached:
-                url = get_url(self.central_info["base_url"], apiPath, query=apiParams)
+                url = get_url(
+                    self.central_info["base_url"], apiPath, query=apiParams)
                 if not headers and not files:
                     headers = {
-                                "Content-Type": "application/json",
-                                "Accept": "application/json"
-                            }
-                if apiData and headers['Content-Type'] == "application/json":
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                    }
+                if apiData and headers["Content-Type"] == "application/json":
                     apiData = json.dumps(apiData)
 
-                resp = self.requestUrl(url=url, data=apiData, method=method,
-                                    headers=headers, params=apiParams,
-                                    files=files)
-                
+                resp = self.requestUrl(
+                    url=url,
+                    data=apiData,
+                    method=method,
+                    headers=headers,
+                    params=apiParams,
+                    files=files,
+                )
+
                 if resp.status_code == 401 and "invalid_token" in resp.text:
-                    self.logger.error("Received error 401 on requesting url "
-                                    "%s with resp %s" % (str(url), str(resp.text)))
+                    self.logger.error(
+                        "Received error 401 on requesting url "
+                        "%s with resp %s" % (str(url), str(resp.text))
+                    )
 
                     if retry >= 1:
                         limit_reached = True
@@ -536,33 +639,46 @@ class ArubaCentralBase:
                     self.handleTokenExpiry()
                     retry += 1
 
-                elif resp.status_code == 429 and resp.headers['X-RateLimit-Remaining-second'] == '0':
+                elif (
+                    resp.status_code == 429
+                    and resp.headers["X-RateLimit-Remaining-second"] == "0"
+                ):
                     time.sleep(2)
-                    self.logger.info("Per-second rate limit reached. Adding 2 seconds interval and retrying.")
-                    if retry == self.user_retries-1:
+                    self.logger.info(
+                        "Per-second rate limit reached. Adding 2 seconds \
+                            interval and retrying."
+                    )
+                    if retry == self.user_retries - 1:
                         limit_reached = True
-                    retry +=1
+                    retry += 1
 
-                elif resp.status_code == 429 and resp.headers['X-RateLimit-Remaining-day'] == '0':
-                    self.logger.info("Per-day rate limit of " + str(resp.headers['X-RateLimit-Limit-day'])
-                                     + " is exhausted. Please check Central UI to see when the daily rate limit quota will be reset.")
+                elif (
+                    resp.status_code == 429
+                    and resp.headers["X-RateLimit-Remaining-day"] == "0"
+                ):
+                    self.logger.info(
+                        "Per-day rate limit of "
+                        + str(resp.headers["X-RateLimit-Limit-day"])
+                        + " is exhausted. Please check Central UI to see when \
+                            the daily rate limit quota will be reset."
+                    )
                     limit_reached = True
                 else:
                     break
 
             result = {
-                        "code": resp.status_code,
-                        "msg": resp.text,
-                        "headers": dict(resp.headers)
-                        }
-            
+                "code": resp.status_code,
+                "msg": resp.text,
+                "headers": dict(resp.headers),
+            }
+
             try:
                 result["msg"] = json.loads(result["msg"])
-            except:
-                result["msg" ] = str(resp.text)
+            except BaseException:
+                result["msg"] = str(resp.text)
 
             return result
-        
+
         except Exception as err:
             self.logger.error(err)
             exit("exiting...")

--- a/pycentral/base_utils.py
+++ b/pycentral/base_utils.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import logging, os
+import logging
+import os
 from urllib.parse import urlencode, urlparse, urlunparse
 try:
     import colorlog  # type: ignore
@@ -29,12 +30,12 @@ except (ImportError, ModuleNotFoundError):
     COLOR = False
 
 C_LOG_LEVEL = {
-  "CRITICAL": 50,
-  "ERROR": 40,
-  "WARNING": 30,
-  "INFO": 20,
-  "DEBUG": 10,
-  "NOTSET":	0
+    "CRITICAL": 50,
+    "ERROR": 40,
+    "WARNING": 30,
+    "INFO": 20,
+    "DEBUG": 10,
+    "NOTSET": 0
 }
 
 C_DEFAULT_ARGS = {
@@ -47,13 +48,17 @@ C_DEFAULT_ARGS = {
     "token": None
 }
 
-def parseInputArgs(central_info):
-    """his method parses user input, checks for the availability of mandatory arguments. Optional missing parameters
-    in central_info variable is initialized as defined in C_DEFAULT_ARGS.
 
-    :param central_info: central_info dictionary as read from user's input file.
+def parseInputArgs(central_info):
+    """This method parses user input, checks for the availability of mandatory\
+        arguments. Optional missing parameters in central_info variable is\
+        initialized as defined in C_DEFAULT_ARGS.
+
+    :param central_info: central_info dictionary as read from user's input\
+        file.
     :type central_info: dict
-    :return: parsed central_info dict with missing optional params set to default values.
+    :return: parsed central_info dict with missing optional params set to\
+        default values.
     :rtype: dict
     """
     if not central_info:
@@ -70,16 +75,22 @@ def parseInputArgs(central_info):
 
     return default_dict
 
+
 def tokenLocalStoreUtil(token_store, customer_id="customer",
                         client_id="client"):
-    """Utility function for storeToken and loadToken default access token storage/cache method.
-    This function generates unique file name for a customer and API gateway client to store and load access
-    token in the local machine for reuse. The format of the file name is tok_<customer_id>_<client_id>.json.
-    If customer_id or client_id is not provided, default values mentioned in args will be used.
+    """Utility function for storeToken and loadToken default access token\
+        storage/cache method. This function generates unique file name for a\
+        customer and API gateway client to store and load access token in the\
+        local machine for reuse. The format of the file name is\
+        tok_<customer_id>_<client_id>.json. If customer_id or client_id is not\
+        provided, default values mentioned in args will be used.
 
-    :param token_store: Placeholder to support different token storage mechanism. \n
-        * keyword type: Place holder for different token storage mechanism. Defaults to local storage. \n
-        * keyword path: path where temp folder is created to store token JSON file. \n
+    :param token_store: Placeholder to support different token storage\
+        mechanism. \n
+        * keyword type: Place holder for different token storage mechanism.\
+            Defaults to local storage. \n
+        * keyword path: path where temp folder is created to store token JSON\
+            file. \n
     :type token_store: dict
     :param customer_id: Aruba Central customer id, defaults to "customer"
     :type customer_id: str, optional
@@ -95,6 +106,7 @@ def tokenLocalStoreUtil(token_store, customer_id="customer",
         filePath = os.path.join(token_store["path"])
     fullName = os.path.join(filePath, fileName)
     return fullName
+
 
 def get_url(base_url, path='', params='', query={}, fragment=''):
     """This method constructs complete URL based on multiple parts of URL.
@@ -119,15 +131,16 @@ def get_url(base_url, path='', params='', query={}, fragment=''):
     url = urlunparse((scheme, netloc, path, params, query, fragment))
     return url
 
-def console_logger(name, level="DEBUG"):
-    """This method create an instance of python logging and sets the following format for log messages.
-    <date> <time> - <name> - <level> - <message>
 
-    :param name: String displayed after data and time. Define it to identify from which part of the code,
-        log message is generated.
+def console_logger(name, level="DEBUG"):
+    """This method create an instance of python logging and sets the following\
+        format for log messages.\n<date> <time> - <name> - <level> - <message>
+
+    :param name: String displayed after data and time. Define it to identify\
+        from which part of the code, log message is generated.
     :type name: str
-    :param level: Loggin level set to display messages from a certain logging level. Refer Python logging
-        library man page, defaults to "DEBUG"
+    :param level: Loggin level set to display messages from a certain logging\
+        level. Refer Python logging library man page, defaults to "DEBUG"
     :type level: str, optional
     :return: An instance of class logging
     :rtype: class:`logging.Logger`
@@ -138,10 +151,15 @@ def console_logger(name, level="DEBUG"):
     f = format
     if COLOR:
         cformat = '%(log_color)s' + format
-        f = colorlog.ColoredFormatter(cformat, date_format,
-              log_colors = { 'DEBUG'   : 'bold_cyan', 'INFO' : 'blue',
-                             'WARNING' : 'yellow', 'ERROR': 'red',
-                             'CRITICAL': 'bold_red' })
+        f = colorlog.ColoredFormatter(
+            cformat,
+            date_format,
+            log_colors={
+                'DEBUG': 'bold_cyan',
+                'INFO': 'blue',
+                'WARNING': 'yellow',
+                'ERROR': 'red',
+                'CRITICAL': 'bold_red'})
     else:
         f = logging.Formatter(format, date_format)
     channel_handler.setFormatter(f)

--- a/pycentral/configuration.py
+++ b/pycentral/configuration.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -28,19 +28,24 @@ urls = ConfigurationUrl()
 DEVICE_TYPES = ["IAP", "ArubaSwitch", "CX", "MobilityController"]
 logger = console_logger("CONFIGURATION")
 
+
 class Groups(object):
-    """A python class consisting of functions to manage Aruba Central Groups via REST API
+    """A python class consisting of functions to manage Aruba Central Groups\
+        via REST API
     """
+
     def get_groups(self, conn, offset=0, limit=20):
         """Get list of groups
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
         :param limit: Pagination limit with Max 20, defaults to 20
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.GROUPS["GET_ALL"]
@@ -52,67 +57,81 @@ class Groups(object):
         return resp
 
     def get_config_mode_groups(self, conn, groups):
-        """For each group in the provided list, the configuration mode for Instant APs and Gateways is
-        specified under the 'Wireless' field and for switches under the 'Wired' field. The configuration
-        mode is specified as a boolean value indicating if the device type is managed using the template
-        mode of configuration or not.
+        """For each group in the provided list, the configuration mode for\
+        Instant APs and Gateways is specified under the 'Wireless' field and\
+        for switches under the 'Wired' field. The configuration mode is\
+        specified as a boolean value indicating if the device type is managed\
+        using the template mode of configuration or not.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param groups: A list of group names with max of 20 groups.
         :type groups: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.GROUPS["GET_TEMPLATE_INFO"]
         params = {
-                    "groups": ",".join(groups)
-                 }
+            "groups": ",".join(groups)
+        }
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def create_group(self, conn, group_name, group_password, wired_template=False, wireless_template=False):
-        """Create new group given a group name, group password and configuration mode(UI or
-        template mode of configuration) to be set per device type.
+    def create_group(self, conn, group_name, group_password,
+                     wired_template=False, wireless_template=False):
+        """Create new group given a group name, group password and\
+        configuration mode(UI or template mode of configuration) to be set per\
+        device type.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of the group to be created.
         :type group_name: str
         :param group_password: Password for the group to be created
         :type group_password: str
-        :param wired_template: Set to True to make the configuration mode for switches to template
-            mode, defaults to False
+        :param wired_template: Set to True to make the configuration mode for\
+            switches to template mode, defaults to False
         :type wired_template: bool, optional
-        :param wireless_template: Set to True to make the configuration mode for IAPs and Gateways to template
-            mode, defaults to False
+        :param wireless_template: Set to True to make the configuration mode\
+            for IAPs and Gateways to template mode, defaults to False
         :type wireless_template: bool, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.GROUPS["CREATE"]
-        data = self._build_group_payload(group_name, group_password, wired_template, wireless_template)
+        data = self._build_group_payload(
+            group_name,
+            group_password,
+            wired_template,
+            wireless_template)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
     def clone_create_group(self, conn, new_group_name, existing_group_name):
-        """Clone and create new group from a given group with the given name. The configuration of the new
-        group will be inherited from the given group.
+        """Clone and create new group from a given group with the given name.\
+            The configuration of the new group will be inherited from the\
+            given group.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param new_group_name: New group name to be created.
         :type new_group_name: str
         :param existing_group_name: Existing group name to be cloned.
         :type existing_group_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.GROUPS["CREATE_CLONE"]
         data = {
-                    "group": new_group_name,
-                    "clone_group": existing_group_name
-                }
+            "group": new_group_name,
+            "clone_group": existing_group_name
+        }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
@@ -121,31 +140,38 @@ class Groups(object):
     #     pass
 
     def delete_group(self, conn, group_name):
-        """Delete an existin group
+        """Delete an existing group
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of the group to be deleted.
         :type group_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.GROUPS["DELETE"], group_name)
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
 
-    def _build_group_payload(self, group_name, group_password, wired_template, wireless_template):
+    def _build_group_payload(
+            self,
+            group_name,
+            group_password,
+            wired_template,
+            wireless_template):
         """Build the HTTP payload for groups config
 
         :param group_name: Name of the group to be created.
         :type group_name: str
         :param group_password: Password for the group to be created
         :type group_password: str
-        :param wired_template: Set to True to make the configuration mode for switches to template
-            mode, defaults to False
+        :param wired_template: Set to True to make the configuration mode for\
+            switches to template mode, defaults to False
         :type wired_template: bool
-        :param wireless_template: Set to True to make the configuration mode for IAPs and Gateways to template
-            mode, defaults to False
+        :param wireless_template: Set to True to make the configuration mode\
+            for IAPs and Gateways to template mode, defaults to False
         :type wireless_template: bool
         :return: HTTP payload for groups config
         :rtype: dict
@@ -162,17 +188,22 @@ class Groups(object):
         }
         return payload_json
 
+
 class Devices(object):
-    """A python class consisting of functions to manage Aruba Central Devices via REST API
+    """A python class consisting of functions to manage Aruba Central Devices\
+        via REST API
     """
+
     def get_devices_group(self, conn, device_serial):
         """Get group name for a device
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of Aruba device
         :type device_serial: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.DEVICES["GET"], device_serial, "group")
@@ -182,11 +213,13 @@ class Devices(object):
     def get_devices_configuration(self, conn, device_serial):
         """Get last known device configuration for a device.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of Aruba device.
         :type device_serial: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.DEVICES["GET"], device_serial, "configuration")
@@ -197,19 +230,26 @@ class Devices(object):
         return resp
 
     def get_devices_config_details(self, conn, device_serial, details=True):
-        """Get 1) central side configuration. 2) Device running configuration.
-        3) Configuration error details. 4) Template error details and status of a device
-        belonging to a template group.
+        """Get \n
+        1. central side configuration.
+        2. Device running configuration.
+        3. Configuration error details.
+        4. Template error details and status of a device belonging to a \
+            template group.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of Aruba device.
         :type device_serial: str
-        :param details: Usually pass false to get only the summary of a device's configuration status. Pass true only
-            if detailed response of a device's configuration status is required. Passing true might result in slower API
-            response and performance effect comparatively., defaults to True
+        :param details: Usually pass false to get only the summary of a\
+            device's configuration status. Pass true only if detailed response\
+            of a device's configuration status is required. Passing true might\
+            result in slower API response and performance effect\
+            comparatively., defaults to True
         :type details: bool, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.DEVICES["GET"], device_serial, "config_details")
@@ -222,11 +262,13 @@ class Devices(object):
     def get_devices_templates(self, conn, device_serials):
         """Get existing templates for list of devices
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serials: List of serial number of Aruba devices
         :type device_serials: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.DEVICES["GET_TEMPLATES"]
@@ -236,26 +278,39 @@ class Devices(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_devices_group_templates(self, conn, device_type="IAP", include_groups=[],
-                                    exclude_groups=[], all_groups=False, offset=0, limit=20):
+    def get_devices_group_templates(
+            self,
+            conn,
+            device_type="IAP",
+            include_groups=[],
+            exclude_groups=[],
+            all_groups=False,
+            offset=0,
+            limit=20):
         """Get templates for devices in a group or multiple groups
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_type: Device type (i.e. IAP/ArubaSwitch/MobilityController/CX), defaults to "IAP"
+        :param device_type: Device type (i.e. IAP/ArubaSwitch/\
+            MobilityController/CX), defaults to "IAP"
         :type device_type: str, optional
-        :param include_groups: Fetch devices templates in list of groups, defaults to []
+        :param include_groups: Fetch devices templates in list of groups,\
+            defaults to []
         :type include_groups: list, optional
-        :param exclude_groups: Fetch devices templates not in list of groups, defaults to []
+        :param exclude_groups: Fetch devices templates not in list of groups,\
+            defaults to []
         :type exclude_groups: list, optional
-        :param all_groups: Set to True, to fetch devices templates details for all the groups
-            (Only allowed for user having all_groups access or admin), defaults to False
+        :param all_groups: Set to True, to fetch devices templates details for\
+            all the groups(Only allowed for user having all_groups access or\
+            admin), defaults to False
         :type all_groups: bool, optional
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
         :param limit: Pagination limit with Max 20, defaults to 20
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.DEVICES["GET_GRP_TEMPLATES"]
@@ -272,23 +327,30 @@ class Devices(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_device_templates_from_hash(self, conn, template_hash, offset=0, limit=20,
-                                  exclude_hash=False, device_type="IAP"):
-        """List of devices with its group name and template information is populated
+    def get_device_templates_from_hash(self, conn, template_hash, offset=0,
+                                       limit=20, exclude_hash=False,
+                                       device_type="IAP"):
+        """List of devices with its group name and template information is\
+            populated
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param template_hash: Template_hash of the template for which list of devices needs to be populated.
+        :param template_hash: Template_hash of the template for which list of\
+            devices needs to be populated.
         :type template_hash: str
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
         :param limit: Pagination limit with Max 20, defaults to 20
         :type limit: int, optional
-        :param exclude_hash: Fetch devices template details not matching with provided hash, defaults to False
+        :param exclude_hash: Fetch devices template details not matching with\
+            provided hash, defaults to False
         :type exclude_hash: bool, optional
-        :param device_type: Device type (i.e. IAP/ArubaSwitch/MobilityController/CX), defaults to "IAP"
+        :param device_type: Device type (i.e. IAP/ArubaSwitch/\
+            MobilityController/CX), defaults to "IAP"
         :type device_type: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.DEVICES["GET"], template_hash, "template")
@@ -304,24 +366,35 @@ class Devices(object):
     def get_switch_variablized_templates(self, conn, device_serial):
         """Get template and variabled for Aruba device (switch)
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of Aruba device.
         :type device_serial: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.DEVICES["GET"], device_serial, "variablised_template")
+        path = urlJoin(
+            urls.DEVICES["GET"],
+            device_serial,
+            "variablised_template")
         headers = {
             "Accept": "multipart/form-data"
         }
         resp = conn.command(apiMethod="GET", apiPath=path, headers=headers)
         return resp
 
-    def set_switch_ssh_credentials(self, conn, device_serial, username, password):
+    def set_switch_ssh_credentials(
+            self,
+            conn,
+            device_serial,
+            username,
+            password):
         """Set SSH connection information of Aruba Device (switch)
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of Aruba device.
         :type device_serial: str
@@ -329,27 +402,35 @@ class Devices(object):
         :type username: str
         :param password: SSH password to set to the device
         :type password: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.DEVICES["SET_SWITCH_CRED"], device_serial, "ssh_connection")
+        path = urlJoin(
+            urls.DEVICES["SET_SWITCH_CRED"],
+            device_serial,
+            "ssh_connection")
         data = {
-                    "username": username,
-                    "password": password
-                }
+            "username": username,
+            "password": password
+        }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
     def move_devices(self, conn, group_name, device_serials):
-        """Move list of devices to group and assign specified group in device management page
+        """Move list of devices to group and assign specified group in device\
+            management page
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of a group where devices will be moved
         :type group_name: str
-        :param device_serials: A list of device serials to be moved to the mentioned group
+        :param device_serials: A list of device serials to be moved to the\
+            mentioned group
         :type device_serials: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.DEVICES["MOVE_DEVICES"]
@@ -360,32 +441,55 @@ class Devices(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
+
 class Templates(object):
-    """A python class consisting of functions to manage Aruba Central Templates via REST API
+    """A python class consisting of functions to manage Aruba Central\
+        Templates via REST API
     """
+
     def get_template_text(self, conn, group_name, template_name):
         """Get CLI template in text format.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of an existing group
         :type group_name: str
-        :param template_name: Name of an existing template within mentioned group
+        :param template_name: Name of an existing template within mentioned\
+            group
         :type template_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.TEMPLATES["GET"], group_name, "templates", template_name)
+        path = urlJoin(
+            urls.TEMPLATES["GET"],
+            group_name,
+            "templates",
+            template_name)
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
-    def get_template(self, conn, group_name, device_type="", template_name="", version="", model="", q="", offset=0, limit=20):
-        """Get all templates in group. Query can be filtered by name, device_type, version, model or version number.
-        Response is sorted by template name.
+    def get_template(
+            self,
+            conn,
+            group_name,
+            device_type="",
+            template_name="",
+            version="",
+            model="",
+            q="",
+            offset=0,
+            limit=20):
+        """Get all templates in group. Query can be filtered by name,\
+            device_type, version, model or version number. Response is sorted\
+            by template name.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param group_name: Name of the group for which the templates will be being queried.
+        :param group_name: Name of the group for which the templates will be\
+            being queried.
         :type group_name: str
         :param device_type: Filter on device_type, defaults to ""
         :type device_type: str, optional
@@ -393,17 +497,19 @@ class Templates(object):
         :type template_name: str, optional
         :param version: Filter on version property of template, defaults to ""
         :type version: str, optional
-        :param model: Filter on model property of template. For 'ArubaSwitch' device_type, part number
-            (J number) can be used., defaults to ""
+        :param model: Filter on model property of template. For 'ArubaSwitch'\
+            device_type, part number(J number) can be used., defaults to ""
         :type model: str, optional
-        :param q: Search for template OR version OR model, q will be ignored if any of filter parameters are
+        :param q: Search for template OR version OR model, q will be ignored\
+            if any of filter parameters are
             provided, defaults to ""
         :type q: str, optional
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
         :param limit: Pagination limit with Max 20, defaults to 20
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.TEMPLATES["GET"], group_name, "templates")
@@ -424,25 +530,33 @@ class Templates(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def create_template(self, conn, group_name, template_name, template_filename, device_type="IAP", version="ALL", model="ALL"):
+    def create_template(self, conn, group_name, template_name,
+                        template_filename, device_type="IAP", version="ALL",
+                        model="ALL"):
         """Upload a new template file
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param group_name: Name of the group in which the template file will be created.
+        :param group_name: Name of the group in which the template file will\
+            be created.
         :type group_name: str
         :param template_name: Name for the template to be created
         :type template_name: str
-        :param template_filename: Name of the template file in local machine to be sent to central using API
+        :param template_filename: Name of the template file in local machine\
+            to be sent to central using API
         :type template_filename: str
         :param device_type: Type of the Aruba device, defaults to "IAP"
         :type device_type: str, optional
-        :param version: Firmware version property of template., defaults to "ALL"
+        :param version: Firmware version property of template., defaults to\
+            "ALL"
         :type version: str, optional
-        :param model: Model property of template. For 'ArubaSwitch' device_type, part number (J number) can be
+        :param model: Model property of template. For 'ArubaSwitch'\
+            device_type, part number (J number) can be
             used, defaults to "ALL"
         :type model: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         # Open template file in binary mode
@@ -451,8 +565,8 @@ class Templates(object):
         try:
             fp = open(template_filename, "rb")
             files = {
-                        "template": fp
-                    }
+                "template": fp
+            }
         except Exception as err:
             logger.error("Unable to open the template file! " + str(err))
             return None
@@ -460,11 +574,11 @@ class Templates(object):
         # Make the API request
         path = urlJoin(urls.TEMPLATES["CREATE"], group_name, "templates")
         params = {
-                        "name": template_name,
-                        "device_type": device_type,
-                        "version": version,
-                        "model": model
-                    }
+            "name": template_name,
+            "device_type": device_type,
+            "version": version,
+            "model": model
+        }
         resp = conn.command(apiMethod="POST", apiPath=path,
                             apiParams=params, files=files)
 
@@ -474,25 +588,37 @@ class Templates(object):
 
         return resp
 
-    def update_template(self, conn, group_name, template_name, template_filename, device_type="", version="", model=""):
+    def update_template(
+            self,
+            conn,
+            group_name,
+            template_name,
+            template_filename,
+            device_type="",
+            version="",
+            model=""):
         """[summary]
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of the group in which the template file exists.
         :type group_name: str
         :param template_name: Name of the template to be modified
         :type template_name: str
-        :param template_filename: Name of the template file in local machine to be sent to central using API
+        :param template_filename: Name of the template file in local machine\
+            to be sent to central using API
         :type template_filename: str
         :param device_type: Aruba device type of the template , defaults to ""
         :type device_type: str, optional
         :param version: Firmware version property of template., defaults to ""
         :type version: str, optional
-        :param model: Device model property of template. For 'ArubaSwitch' device_type, part number (J number) can be
+        :param model: Device model property of template. For 'ArubaSwitch'\
+            device_type, part number (J number) can be
             used, defaults to ""
         :type model: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         # Open template file in binary mode
@@ -501,8 +627,8 @@ class Templates(object):
         try:
             fp = open(template_filename, "rb")
             files = {
-                        "template": fp
-                    }
+                "template": fp
+            }
         except Exception as err:
             logger.error("Unable to open the template file! " + str(err))
             return None
@@ -530,49 +656,68 @@ class Templates(object):
     def delete_template(self, conn, group_name, template_name):
         """Delete an existing template
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group_name: Name of the group in which the template file exists.
         :type group_name: str
         :param template_name: Name of the template to be deleted.
         :type template_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.TEMPLATES["GET"], group_name, "templates", template_name)
+        path = urlJoin(
+            urls.TEMPLATES["GET"],
+            group_name,
+            "templates",
+            template_name)
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
 
+
 class Variables(object):
-    """A python class consisting of functions to manage Aruba Central Variables via REST API
+    """A python class consisting of functions to manage Aruba Central\
+        Variables via REST API
     """
+
     def get_template_variables(self, conn, device_serial):
         """Get template variables for a device
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of the device.
         :type device_serial: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.VARIABLES["GET"], device_serial, "template_variables")
+        path = urlJoin(
+            urls.VARIABLES["GET"],
+            device_serial,
+            "template_variables")
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
-    def get_all_template_variables(self, conn, offset=0, limit=20, format="JSON"):
+    def get_all_template_variables(self, conn, offset=0, limit=20,
+                                   format="JSON"):
         """Get template variables for all devices
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param offset: Pagination offset. Number of items to be skipped before returning the data,
+        :param offset: Pagination offset. Number of items to be skipped before\
+            returning the data,
             useful for pagination, defaults to 0
         :type offset: int, optional
-        :param limit: Pagination limit. Maximum number of records to be returned, defaults to 20
+        :param limit: Pagination limit. Maximum number of records to be\
+            returned, defaults to 20
         :type limit: int, optional
         :param format: Format in which output is desired, defaults to "JSON"
         :type format: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.VARIABLES["GET_ALL"]
@@ -587,33 +732,48 @@ class Variables(object):
     def create_template_variables(self, conn, device_serial, variables):
         """Create template variable for a device
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_serial: Serial Number of a device for which the variables are to be created.
+        :param device_serial: Serial Number of a device for which the\
+            variables are to be created.
         :type device_serial: str
-        :param variables: Variables defined in template file to be applied for a device
-            Sample Variables {"_sys_serial": "AB0011111", "_sys_lan_mac": "11:12:AA:13:14:BB", "SSID_A": "Z-Employee"}
+        :param variables: Variables defined in template file to be applied for\
+            a device. Sample Variables - \n
+            {"_sys_serial": "AB0011111", \
+            "_sys_lan_mac": "11:12:AA:13:14:BB",\
+            "SSID_A": "Z-Employee"}
         :type variables: dict
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.VARIABLES["CREATE"], device_serial, "template_variables")
+        path = urlJoin(
+            urls.VARIABLES["CREATE"],
+            device_serial,
+            "template_variables")
         data = {
-                    "variables": variables
-                }
+            "variables": variables
+        }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def create_template_variables_file(self, conn, variables_filename, format="JSON"):
-        """Create template variables for multiple devices defined in JSON format in a file
+    def create_template_variables_file(
+            self, conn, variables_filename, format="JSON"):
+        """Create template variables for multiple devices defined in JSON\
+            format in a file
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param variables_filename: Name of the variable file to be sent to Central via API.
+        :param variables_filename: Name of the variable file to be sent to\
+            Central via API.
         :type variables_filename: str
-        :param format: Format of data in the file to be uploaded, defaults to "JSON"
+        :param format: Format of data in the file to be uploaded, defaults to\
+            "JSON"
         :type format: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.VARIABLES["CREATE_ALL"]
@@ -627,8 +787,8 @@ class Variables(object):
         try:
             fp = open(variables_filename, "rb")
             files = {
-                        "variables": fp
-                    }
+                "variables": fp
+            }
         except Exception as err:
             logger.error("Unable to open the variable file! " + str(err))
             return None
@@ -643,19 +803,25 @@ class Variables(object):
         return resp
 
     def update_template_variables(self, conn, device_serial, variables):
-        """Update values of existing template variables and add new variabels to the existing
-        set of variables for a device.
+        """Update values of existing template variables and add new variables\
+            to the existing set of variables for a device.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of a device
         :type device_serial: str
-        :param variables: Template variables to be updated for the mentioned device
+        :param variables: Template variables to be updated for the mentioned\
+            device
         :type variables: dict
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.VARIABLES["UPDATE"], device_serial, "template_variables")
+        path = urlJoin(
+            urls.VARIABLES["UPDATE"],
+            device_serial,
+            "template_variables")
         data = {
             "variables": variables
         }
@@ -663,14 +829,18 @@ class Variables(object):
         return resp
 
     def update_template_variables_file(self, conn, variables_filename):
-        """Update values of existing template variables and add new variabels to the existing
-        set of variables for multiple devices defined in the specified file.
+        """Update values of existing template variables and add new variables\
+            to the existing set of variables for multiple devices defined in\
+            the specified file.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param variables_filename: Local filename of template variables to be uploaded to Central via API.
+        :param variables_filename: Local filename of template variables to be\
+            uploaded to Central via API.
         :type variables_filename: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.VARIABLES["UPDATE_ALL"]
@@ -681,8 +851,8 @@ class Variables(object):
         try:
             fp = open(variables_filename, "rb")
             files = {
-                        "variables": fp
-                    }
+                "variables": fp
+            }
         except Exception as err:
             logger.error("Unable to open the variable file! " + str(err))
             return None
@@ -696,36 +866,48 @@ class Variables(object):
         return resp
 
     def replace_template_variables(self, conn, device_serial, variables):
-        """Delete all existing template variables and create requested template variables for a device.
-        This API can be used for deleting some variables out of all for a device.
+        """Delete all existing template variables and create requested\
+            template variables for a device. This API can be used for deleting\
+            some variables out of all for a device.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of a device
         :type device_serial: str
-        :param variables: Delete existing template variables for a device and replace with the new variables.
+        :param variables: Delete existing template variables for a device and\
+            replace with the new variables.
         :type variables: dict
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.VARIABLES["UPDATE"], device_serial, "template_variables")
+        path = urlJoin(
+            urls.VARIABLES["UPDATE"],
+            device_serial,
+            "template_variables")
         data = {
             "variables": variables
         }
         resp = conn.command(apiMethod="PUT", apiPath=path, apiData=data)
         return resp
 
-    def replace_template_variables_file(self, conn, variables_filename, format="JSON"):
-        """Delete all existing template variables and create requested template variables for all devices.
-        This API can be used for deleting some variables out of all for all devices.
+    def replace_template_variables_file(
+            self, conn, variables_filename, format="JSON"):
+        """Delete all existing template variables and create requested\
+            template variables for all devices. This API can be used for\
+            deleting some variables out of all for all devices.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param variables_filename: filename of template variables to be uploaded to Central via API from local machine.
+        :param variables_filename: filename of template variables to be\
+            uploaded to Central via API from local machine.
         :type variables_filename: str
         :param format: Data format of the specified file, defaults to "JSON"
         :type format: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urls.VARIABLES["CREATE_ALL"]
@@ -739,8 +921,8 @@ class Variables(object):
         try:
             fp = open(variables_filename, "rb")
             files = {
-                        "variables": fp
-                    }
+                "variables": fp
+            }
         except Exception as err:
             logger.error("Unable to open the variable file! " + str(err))
             return None
@@ -757,54 +939,69 @@ class Variables(object):
     def delete_template_variables(self, conn, device_serial):
         """Delete all existing template variables for a device
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Serial number of a device
         :type device_serial: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
-        path = urlJoin(urls.VARIABLES["DELETE"], device_serial, "template_variables")
+        path = urlJoin(
+            urls.VARIABLES["DELETE"],
+            device_serial,
+            "template_variables")
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
+
 
 class ApSettings(object):
     """A Python class to manage AP settings such as AP name, zonename, etc.
     """
+
     def get_ap_settings(self, conn, serial_number: str):
         """Get existing AP settings
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param serial_number: Serial number of an AP. Example: CNBRHMV3HG
         :type serial_number: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.AP_SETTINGS["GET"], serial_number)
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
-    def update_ap_settings(self, conn, serial_number: str, ap_settings_data: dict):
+    def update_ap_settings(self, conn, serial_number: str,
+                           ap_settings_data: dict):
         """Update Existing AP Settings
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param serial_number: Serial number of an AP. Example: CNBRHMV3HG
         :type serial_number: str
         :param ap_settings_data: Data to update ap settings. \n
             * keyword hostname: Name string to set to the AP \n
-            * keyword ip_address: IP Address string to set to AP. Should be set to "0.0.0.0" if AP get IP from DHCP. \n
+            * keyword ip_address: IP Address string to set to AP. Should be\
+                set to "0.0.0.0" if AP get IP from DHCP. \n
             * keyword zonename: Zonename string to set to AP \n
             * keyword achannel: achannel string to set to AP \n
             * keyword atxpower: atxpower string to set to AP \n
             * keyword gchannel: gchannel string to set to AP \n
             * keyword gtxpower: gtxpower string to set to AP \n
-            * keyword dot11a_radio_disable: dot11a_radio_disable string to set to AP \n
-            * keyword dot11g_radio_disable: dot11g_radio_disable string to set to AP \n
+            * keyword dot11a_radio_disable: dot11a_radio_disable string to set\
+                to AP \n
+            * keyword dot11g_radio_disable: dot11g_radio_disable string to set\
+                to AP \n
             * keyword usb_port_disable: usb_port_disable string to set to AP \n
         :type ap_settings_data: dict
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`.
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`.
         :rtype: dict
         """
         path = urlJoin(urls.AP_SETTINGS["UPDATE"], serial_number)
@@ -860,6 +1057,7 @@ class Wlan(object):
     """A python class consisting of functions to manage Aruba Central WLANs
     via REST API.
     """
+
     def create_wlan(self, conn, group_name, wlan_name, wlan_data):
         """
         Create new WLAN.

--- a/pycentral/constants.py
+++ b/pycentral/constants.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/pycentral/device_inventory.py
+++ b/pycentral/device_inventory.py
@@ -28,6 +28,7 @@ urls = InventoryUrl()
 
 MAX_DEVICES = 100
 
+
 class Inventory(object):
     """
     A python class consisting of functions to manage Aruba Central inventory
@@ -74,116 +75,178 @@ class Inventory(object):
         return resp
 
     def archive_devices(self, conn, device_serials=[]):
-        """Archive a list of devices using serial numbers 
+        """Archive a list of devices using serial numbers
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_serials: List of serial number of Aruba devices that should be archived
+        :param device_serials: List of serial number of Aruba devices that\
+            should be archived
         :type device_serials: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.DEVICES["ARCHIVE_DEVICES"]
         if isinstance(device_serials, str):
             device_serials = [device_serials]
         if (len(device_serials)) > MAX_DEVICES:
-            logger.error('Unable to archive more than {MAX_DEVICES} devices per API call. Please archive {MAX_DEVICES} or less devices at a time.')        
+            logger.error(
+                'Unable to archive more than {MAX_DEVICES} devices per API \
+                call. Please archive {MAX_DEVICES} or less devices at a time.')
             return
         if len(device_serials) == 0:
-            logger.error("Unable to archive devices since no device serial numbers were provided. Please provide atleast one device's details in the device_serials function argument.")        
+            logger.error(
+                "Unable to archive devices since no device serial numbers were\
+                provided. Please provide atleast one device's details in the\
+                device_serials function argument.")
             return
-        
+
         apiData = {
             "serials": device_serials
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=apiData)
         # Devices in the succeeded_devices list
-        successful_devices = [device["serial_number"] for device in resp['msg']['succeeded_devices']]
+        successful_devices = [device["serial_number"]
+                              for device in resp['msg']['succeeded_devices']]
         # Devices in the failed_devices list
-        failed_devices = [device["serial_number"] for device in resp['msg']['failed_devices']]
+        failed_devices = [device["serial_number"]
+                          for device in resp['msg']['failed_devices']]
         if (resp["code"] == 200 and len(failed_devices) == 0):
-            logger.info(f'Successfully archived devices with SN - {", ".join(str(device) for device in successful_devices)}')
+            logger.info(
+                f'Successfully archived devices with SN - \
+                    {", ".join(str(device) for device in successful_devices)}')
         elif (resp["code"] == 200 and len(failed_devices) > 0):
-            logger.error(f'Failed to archive devices with SN - {", ".join(str(device) for device in failed_devices)}')
+            logger.error(
+                f'Failed to archive devices with SN - \
+                    {", ".join(str(device) for device in failed_devices)}')
             if (len(successful_devices) > 0):
-                logger.info(f'Successfully unarchived devices with SN - {", ".join(str(device) for device in successful_devices)}')
+                logger.info(
+                    f'Successfully unarchived devices with SN - \
+                    {", ".join(str(device) for device in successful_devices)}')
         else:
-            logger.error(f'Error in API Response. Response Code - {resp["code"]}')
+            logger.error(
+                f'Error in API Response. Response Code - {resp["code"]}')
         return resp
-    
-    def unarchive_devices(self, conn, device_serials=[]):
-        """Unarchive a list of devices using serial numbers 
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+    def unarchive_devices(self, conn, device_serials=[]):
+        """Unarchive a list of devices using serial numbers
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_serials: List of serial number of Aruba devices that should be unarchived
+        :param device_serials: List of serial number of Aruba devices that\
+            should be unarchived
         :type device_serials: list
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.DEVICES["UNARCHIVE_DEVICES"]
         if isinstance(device_serials, str):
             device_serials = [device_serials]
-        
+
         if (len(device_serials)) > MAX_DEVICES:
-            logger.error('Unable to unarchive more than {MAX_DEVICES} devices per API call. Please unarchive {MAX_DEVICES} or less devices at a time.')        
+            logger.error(
+                'Unable to unarchive more than {MAX_DEVICES} devices per API\
+                call. Please unarchive {MAX_DEVICES} or less devices at a\
+                time.')
             return
         if len(device_serials) == 0:
-            logger.error("Unable to unarchive devices since no device serial numbers were provided. Please provide atleast one device's details in the device_serials function argument.")        
+            logger.error("Unable to unarchive devices since no device serial \
+                         numbers were provided. Please provide atleast one \
+                         device's details in the device_serials function \
+                         argument.")
             return
-        
+
         apiData = {
             "serials": device_serials
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=apiData)
         # Devices in the succeeded_devices list
-        successful_devices = [device["serial_number"] for device in resp['msg']['succeeded_devices']]
+        successful_devices = [device["serial_number"]
+                              for device in resp['msg']['succeeded_devices']]
         # Devices in the failed_devices list
-        failed_devices = [device["serial_number"] for device in resp['msg']['failed_devices']]
+        failed_devices = [device["serial_number"]
+                          for device in resp['msg']['failed_devices']]
         if (resp["code"] == 200 and len(failed_devices) == 0):
-            logger.info(f'Successfully unarchived devices with SN - {", ".join(str(device) for device in successful_devices)}')
+            logger.info(
+                f'Successfully unarchived devices with SN - \
+                {", ".join(str(device) for device in successful_devices)}')
         elif (resp["code"] == 200 and len(failed_devices) > 0):
-            logger.error(f'Failed to unarchive devices with SN - {", ".join(str(device) for device in failed_devices)}')
+            logger.error(
+                f'Failed to unarchive devices with SN - \
+                    {", ".join(str(device) for device in failed_devices)}')
             if (len(successful_devices) > 0):
-                logger.info(f'Successfully unarchived devices with SN - {", ".join(str(device) for device in successful_devices)}')
+                logger.info(
+                    f'Successfully unarchived devices with SN - \
+                    {", ".join(str(device) for device in successful_devices)}')
         else:
-            logger.error(f'Error in API Response. Response Code - {resp["code"]}')
+            logger.error(
+                f'Error in API Response. Response Code - {resp["code"]}')
         return resp
-    
+
     def add_devices(self, conn, device_details):
         """Add device(s) using Mac & Serial Numbers
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_details: List of dictionaries with Aruba devices that should be added to the Aruba Central account. Each item in the dictionary should have the following keys - mac & serial. For Central On-Premises account, an additional key is required in the dictionary - partNumber
+        :param device_details: List of dictionaries with Aruba devices that\
+            should be added to the Aruba Central account. Each item in the\
+            dictionary should have the following keys - `mac` & `serial`. For\
+            Central On-Premises account, an additional key is required in the\
+            dictionary - `partNumber`
         :type device_details: list
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         if (len(device_details)) > MAX_DEVICES:
-            logger.error('Unable to add more than {MAX_DEVICES} devices per API call. Please add {MAX_DEVICES} or less devices at a time.')        
+            logger.error(
+                'Unable to add more than {MAX_DEVICES} devices per API call.\
+                Please add {MAX_DEVICES} or less devices at a time.')
             return
         if len(device_details) == 0:
-            logger.error("No device details were provided. Please provide atleast one device's details in the device_details function argument.")        
+            logger.error(
+                "No device details were provided. Please provide atleast one\
+                device's details in the device_details function argument.")
             return
-        
+
         path = urls.DEVICES["ADD_DEVICE"]
         apiData = device_details
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=apiData)
+        extra_resp = None
+        if 'extra' in resp['msg']:
+            extra_resp = resp['msg']['extra']
         if (resp["code"] == 200):
-            device_serials = [device["serial"] for device in resp['msg']['extra']['message']["available_device"]]
-            logger.info(f'Successfully added devices(with SN - {", ".join(str(device) for device in device_serials)}) to Greenlake Device Inventory.')
-        elif (resp["code"] == 400 and 'extra' in resp['msg']):
-            if (resp['msg']['extra']['error_code'] == 'ATHENA_ERROR_NO_DEVICE' and len(error_devices) > 0):
+            avail_devices = extra_resp['message']["available_device"]
+            device_serials = [device["serial"] for device in avail_devices]
+            logger.info(
+                f'Successfully added devices(with SN - \
+                {", ".join(str(device) for device in device_serials)}) \
+                to Greenlake Device Inventory.')
+        elif (resp["code"] == 400 and extra_resp is not None):
+            if (extra_resp['error_code'] == 'ATHENA_ERROR_NO_DEVICE' and
+                    len(error_devices) > 0):
                 # Devices that were in the available_list
-                successful_devices = resp['msg']['extra']['message']["available_device"]
+                successful_devices = extra_resp['message']["available_device"]
                 # Devices that were either on the blocked_list or invalid_list
-                error_devices = resp['msg']['extra']['message']['blocked_device'] + resp['msg']['extra']['message']['invalid_device']
-                logger.error('Some or all of the devices were not added to the device inventory.')
+                error_devices = extra_resp['message']['blocked_device'] + \
+                    extra_resp['message']['invalid_device']
+                logger.error(
+                    'Some or all of the devices were not added to the device\
+                    inventory.')
                 for device in error_devices:
-                    logger.error(f'Unable to add device({device["serial"]}). Reason for error - {device["ccs_message"]}')
+                    logger.error(
+                        f'Unable to add device({device["serial"]}). Reason for\
+                            error - {device["ccs_message"]}')
                 for device in successful_devices:
-                    logger.info(f'Able to add device({device["serial"]}). Reason for error - {device["ccs_message"]}')
+                    logger.info(
+                        f'Able to add device({device["serial"]}). Reason for\
+                            error - {device["ccs_message"]}')
         else:
-            logger.error(f'Error in API Response. Response Code - {resp["code"]}, Error Message - {resp["msg"]["detail"]}')
+            logger.error(
+                f'Error in API Response. Response Code - {resp["code"]}, Error\
+                    Message - {resp["msg"]["detail"]}')
         return resp

--- a/pycentral/firmware_management.py
+++ b/pycentral/firmware_management.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,22 +25,27 @@ from pycentral.base_utils import console_logger
 
 urls = FirmwareManagementUrl()
 
+
 class Firmware():
     """A Python Class to manage Aruba Central Device Firmware via REST APIs.
     """
-    def list_firmware_all_swarms(self, conn, group=None, limit=20, offset=0):
-        """Get a list of swarms with their firmware details. You can optionally specify a group,
-        to filter devices under it
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+    def list_firmware_all_swarms(self, conn, group=None, limit=20, offset=0):
+        """Get a list of swarms with their firmware details. You can \
+            optionally specify a group, to filter devices under it
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: Name of the group, defaults to None
         :type group: str, optional
-        :param limit: Pagination limit. Default is 20 and max is 1000, defaults to 20
+        :param limit: Pagination limit. Default is 20 and max is 1000,\
+            defaults to 20
         :type limit: int, optional
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FIRMWARE["GET_ALL_SWARMS"]
@@ -56,11 +61,13 @@ class Firmware():
     def get_firmware_swarm(self, conn, swarm_id):
         """Get firmware details for specific swarm.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param swarm_id: Swarm ID for which the firmware detail to be queried
         :type swarm_id: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FIRMWARE["GET_SWARM"], swarm_id)
@@ -69,20 +76,25 @@ class Firmware():
 
     def list_supported_version(self, conn, device_type=None, swarm_id=None,
                                serial=None):
-        """Get list of firmware versions for device. Specify device_type "IAP"/"MAS"/"HP"/"CONTROLLER"
-        to get firmware versions for swarms, MAS switches, aruba switches and controllers respectively
-        or you can specify swarm_id to get list of supported version for specific swarm or you can
-        specify serial to get list of supported version for specific device.
+        """Get list of firmware versions for device. Specify device_type\
+            "IAP"/"MAS"/"HP"/"CONTROLLER" to get firmware versions for swarms,\
+            MAS switches, aruba switches and controllers respectively or you\
+            can specify swarm_id to get list of supported version for specific\
+            swarm or you can specify serial to get list of supported version\
+            for specific device.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults to None
+        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults\
+            to None
         :type device_type: str, optional
         :param swarm_id: Swarm ID, defaults to None
         :type swarm_id: str, optional
         :param serial: Serial of device, defaults to None
         :type serial: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FIRMWARE["GET_VERSIONS_IAP"]
@@ -94,27 +106,33 @@ class Firmware():
         elif serial:
             params["serial"] = serial
         else:
-            conn.logger.error("Failed to check supported formware version! \
-                Missing required parameter: device_type or swarm_id or serial!")
+            conn.logger.error(
+                "Failed to check supported formware version! \
+            Missing required parameter: device_type or swarm_id or serial!")
             return None
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
     def check_firmware_support(self, conn, firmware_version, device_type):
-        """Check whether specific firmware version is available or not. Specify device_type
-        "IAP"/"MAS"/"HP"/"CONTROLLER" to get firmware versions for
-        swarms/MAS switches/aruba switches/controllers respectively.
+        """Check whether specific firmware version is available or not.\
+            Specify device_type "IAP"/"MAS"/"HP"/"CONTROLLER" to get firmware\
+            versions for swarms/MAS switches/aruba switches/controllers\
+            respectively.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param firmware_version: Firmware Version
         :type firmware_version: str
         :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER"
         :type device_type: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = urlJoin(urls.FIRMWARE["CHECK_VERSION_SUPPORT"], firmware_version)
+        path = urlJoin(
+            urls.FIRMWARE["CHECK_VERSION_SUPPORT"],
+            firmware_version)
         print("DEbug!! ", path)
         params = {
             "device_type": device_type
@@ -123,16 +141,19 @@ class Firmware():
         return resp
 
     def check_firmware_status(self, conn, serial=None, swarm_id=None):
-        """Get firmware upgrade status of device. You can either specify swarm_id if device_type is
+        """Get firmware upgrade status of device. You can either specify\
+            swarm_id if device_type is
         "IAP" or serial for rest of device_type, but not both.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param serial: Serial of device, defaults to None
         :type serial: str, optional
         :param swarm_id: Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FIRMWARE["GET_STATUS"]
@@ -151,38 +172,48 @@ class Firmware():
     def upgrade_firmware(self, conn, firmware_version, reboot=True,
                          device_type=None, model=None, group=None, serial=None,
                          swarm_id=None, schedule_at=None):
-        """Upgrade firmware version for a device or for a whole group of devices under a device type,
-        with additional filter of model. To initiate upgrade for certain type of devices of specific
-        group, specify device_type as one of "IAP" for swarm, "MAS" for MAS switches,
-        "HP" for aruba switches, "CONTROLLER" for controllers respectively, and group name.
-        To upgrade a device, you can specify swarm_id to upgrade a specific swarm or serial to
-        upgrade a specific device. To upgrade a specific model of Aruba switches at group level,
-        please use model in request body.
+        """Upgrade firmware version for a device or for a whole group of\
+            devices under a device type, with additional filter of model. To\
+            initiate upgrade for certain type of devices of specific group,\
+            specify device_type as one of "IAP" for swarm, "MAS" for MAS\
+            switches, "HP" for aruba switches, "CONTROLLER" for controllers\
+            respectively, and group name. To upgrade a device, you can specify\
+            swarm_id to upgrade a specific swarm or serial to upgrade a\
+            specific device. To upgrade a specific model of Aruba switches at\
+            group level, please use model in request body.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param firmware_version: Specify firmware version to which you want device to upgrade. If
-            you do not specify this field then firmware upgrade initiated with recommended firmware version
+        :param firmware_version: Specify firmware version to which you want\
+            device to upgrade. If you do not specify this field then firmware\
+            upgrade initiated with recommended firmware version
         :type firmware_version: str
-        :param reboot: Use True for auto reboot after successful firmware download. Default value is False.
-            Applicable only on MAS, aruba switches and controller since IAP reboots automatically after
+        :param reboot: Use True for auto reboot after successful firmware\
+            download. Default value is False. Applicable only on MAS, Aruba\
+            switches and controller since IAP reboots automatically after \
             firmware download., defaults to True
         :type reboot: bool, optional
-        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults to None
+        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults\
+            to None
         :type device_type: str, optional
-        :param model: To initiate upgrade at group level for specific model family. Applicable only for Aruba
-            switches., defaults to None
+        :param model: To initiate upgrade at group level for specific model\
+            family. Applicable only for Aruba switches, defaults to None
         :type model: str, optional
-        :param group: Specify Group Name to initiate upgrade for whole group., defaults to None
+        :param group: Specify Group Name to initiate upgrade for whole group.,\
+            defaults to None
         :type group: str, optional
         :param serial: Serial of device, defaults to None
         :type serial: str, optional
         :param swarm_id: Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param schedule_at: Firmware upgrade will be scheduled at, firmware_scheduled_at - current time.
-            firmware_scheduled_at is epoch in seconds and default value is current time, defaults to None
+        :param schedule_at: Firmware upgrade will be scheduled at, \
+            `firmware_scheduled_at` - current time. firmware_scheduled_at is\
+            epoch in seconds and default value is current time, defaults to\
+            None
         :type schedule_at: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FIRMWARE["UPGRADE"]
@@ -207,23 +238,29 @@ class Firmware():
 
     def cancel_scheduled_upgrade(self, conn, serial=None, swarm_id=None,
                                  device_type=None, group=None):
-        """Cancel scheduled firmware upgrade for a device or for a whole group of devices. To Cancel
-        scheduled upgrade for certain type of devices of specific group, specify device_type as one
-        of "IAP" for swarm, "MAS" for MAS switches, "HP" for aruba switches, "CONTROLLER" for
-        controllers respectively, and the group as the group name. To Cancel scheduled upgrade a
-        device, you can specify swarm_id of the specific swarm or serial of the specific device.
+        """Cancel scheduled firmware upgrade for a device or for a whole group\
+            of devices. To cancel scheduled upgrade for certain type of\
+            devices of specific group, specify device_type as one of "IAP" for\
+            swarm, "MAS" for MAS switches, "HP" for aruba switches,\
+            "CONTROLLER" for controllers respectively, and the group as the\
+            group name. To cancel scheduled upgrade a device, you can specify\
+            swarm_id of the specific swarm or serial of the specific device.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param serial: Serial of device, defaults to None
         :type serial: str, optional
         :param swarm_id: Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults to None
+        :param device_type: Specify one of "IAP/MAS/HP/CONTROLLER", defaults\
+            to None
         :type device_type: str, optional
-        :param group: Specify Group Name to initiate upgrade for whole group., defaults to None
+        :param group: Specify Group Name to initiate upgrade for whole group,\
+            defaults to None
         :type group: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FIRMWARE["CANCEL"]
@@ -238,4 +275,3 @@ class Firmware():
             data["group"] = group
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
-

--- a/pycentral/licensing.py
+++ b/pycentral/licensing.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,13 +25,17 @@ from pycentral.base_utils import console_logger
 
 urls = LicensingUrl()
 
+
 class Subscriptions(object):
     """A python class to manage subscriptions for Aruba Central
     """
-    def get_user_subscription_keys(self, conn, license_type="", offset=0, limit=100):
+
+    def get_user_subscription_keys(self, conn, license_type="", offset=0,
+                                   limit=100):
         """This function is used to get license subscription keys
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param license_type: Accepts basic/special, defaults to ""
         :type license_type: str, optional
@@ -39,7 +43,8 @@ class Subscriptions(object):
         :type offset: int, optional
         :param limit: Number of subscriptions to get, defaults to 100
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["GET_KEYS"]
@@ -53,11 +58,14 @@ class Subscriptions(object):
         return resp
 
     def get_enabled_services(self, conn):
-        """This function is used to get the list of services which are enabled for customer.
+        """This function is used to get the list of services which are enabled\
+            for customer.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["GET_ENABLED_SVC"]
@@ -65,57 +73,70 @@ class Subscriptions(object):
         return resp
 
     def assign_device_subscription(self, conn, device_serials, services):
-        """This function is used to assign subscriptions to device by specifying its serial.
+        """This function is used to assign subscriptions to device by\
+            specifying its serial.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serials: List of serial number of device.
         :type device_serials: list
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["ASSIGN"]
         data = {
-                "serials": device_serials,
-                "services": services
+            "serials": device_serials,
+            "services": services
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
     def unassign_device_subscription(self, conn, device_serials, services):
-        """This function is used to unassign subscriptions to device by specifying its serial.
+        """This function is used to unassign subscriptions to device by\
+            specifying its serial.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serials: List of serial number of device.
         :type device_serials: list
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["UNASSIGN"]
         data = {
-                "serials": device_serials,
-                "services": services
+            "serials": device_serials,
+            "services": services
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def get_user_subscription_status(self, conn, license_type="all", service=""):
+    def get_user_subscription_status(self, conn, license_type="all",
+                                     service=""):
         """This function is used to return subscription stats.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param license_type: basic/special/all. special - will fetch the statistics of special central
-            services like presence analytics(pa), ucc, clarity etc basic - will fetch the statistics of
-            device management service licenses, all - will fetch both of these license types, defaults to "all"
+        :param license_type: basic/special/all. special - will fetch the\
+            statistics of special central services like presence\
+            analytics(pa), ucc, clarity etc basic - will fetch the statistics\
+            of device management service licenses, all - will fetch both of\
+            these license types, defaults to "all"
         :type license_type: str, optional
         :param service: Service type: pa/pa,clarity etc, defaults to ""
         :type service: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["GET_STATS"]
@@ -127,16 +148,20 @@ class Subscriptions(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_services_license_config(self, conn, service_category="", device_type=""):
-        """This function is used to return services configuration for licensing purpose.
+    def get_services_license_config(self, conn, service_category="",
+                                    device_type=""):
+        """This function is used to return services configuration for\
+            licensing purpose.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param service_category: Service category - dm/network, defaults to ""
         :type service_category: str, optional
         :param device_type: Device Type - iap/switch, defaults to ""
         :type device_type: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["GET_LIC_SVC"]
@@ -149,58 +174,77 @@ class Subscriptions(object):
         return resp
 
     def assign_subscription_all(self, conn, services):
-        """This function is used to assign licenses to all devices for given services.
+        """This function is used to assign licenses to all devices for given\
+            services. \n
         Note: This API is not applicable for MSP customer
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["ASSIGN_LIC"]
         data = {
-                "services": services
+            "services": services
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
     def unassign_subscription_all(self, conn, services):
-        """This function is used to unassign licenses to all devices for given services.
+        """This function is used to unassign licenses to all devices for given\
+            services.\n
         Note: This API is not applicable for MSP customer
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["UNASSIGN_LIC"]
         data = {
-                "services": services
+            "services": services
         }
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
 
-    def assign_msp_subscription_all(self, conn, services, include_customers=[], exclude_customers=[]):
-        """Assign licenses to all devices owned by tenant customers for given services. If include_customers and
-        exclude_customers parameters are not provided, licenses will be assigned for all customers(MSP, tenants) devices.
-        Note: License assignment is not supported for the MSP owned devices Since it is a background job,
-        please wait for few minutes for all devices to be subscribed in case of customer having large number of devices
+    def assign_msp_subscription_all(self, conn, services, include_customers=[],
+                                    exclude_customers=[]):
+        """Assign licenses to all devices owned by tenant customers for given\
+        services. If include_customers and exclude_customers parameters are\
+        not provided, licenses will be assigned for all customers(MSP, \
+        tenants) devices. \n
+        Note: License assignment is not supported for the MSP owned devices.\
+        Since it is a background job, please wait for few minutes for all\
+        devices to be subscribed in case of customer having large number of\
+        devices
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :param include_customers:  if provided, licenses will be assigned only for the customers present in
-            include_customers list(Exception: License assignment will be ignored for MSP owned devices), default=[]
+        :param include_customers:  if provided, licenses will be assigned only\
+            for the customers present in include_customers list\n
+            (Exception: License assignment will be ignored for MSP owned \
+            devices), default=[]
         :type include_customers: list, optional
-        :param exclude_customers:  if provided, licenses will be assigned for msp/tenant customers except the
-            customers present in exclude_customers list, default=[]
+        :param exclude_customers:  if provided, licenses will be assigned for\
+            MSP/tenant customers except the customers present in\
+            exclude_customers list, default=[]
         :type exclude_customers: list, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["ASSIGN_LIC_MSP"]
@@ -214,25 +258,36 @@ class Subscriptions(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def unassign_msp_subscription_all(self, conn, services, include_customers=[], exclude_customers=[]):
-        """Remove service licenses to all devices the devices owned by tenant and MSP. However license assignment is not
-        supported for the MSP owned devices but un-assignment is supported for the customers who are transitioning from
-        Non-MSP to MSP mode to release license quantity for better utilization.
+    def unassign_msp_subscription_all(self, conn, services,
+                                      include_customers=[],
+                                      exclude_customers=[]):
+        """Remove service licenses to all devices the devices owned by tenant\
+        and MSP. However license assignment is not supported for the MSP owned\
+        devices but un-assignment is supported for the customers who are\
+        transitioning from Non-MSP to MSP mode to release license quantity for\
+        better utilization. \n
 
-        Note: If include_customers and exclude_customers parameters are not provided, licenses will be unassigned for
-        all customers(MSP, tenants) devices.
+        Note: If include_customers and exclude_customers parameters are not\
+        provided, licenses will be unassigned for all customers(MSP, tenants)\
+        devices.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :param include_customers:  if provided, licenses will be unassigned only for the customers present in
-            include_customers list(Exception: License assignment will be ignored for MSP owned devices), default=[]
+        :param include_customers:  if provided, licenses will be unassigned\
+            only for the customers present in include_customers list.\n
+            (Exception: License assignment will be ignored for MSP owned \
+            devices), default=[]
         :type include_customers: list, optional
-        :param exclude_customers:  if provided, licenses will be unassigned for msp/tenant customers except the
-            customers present in exclude_customers list, default=[]
+        :param exclude_customers:  if provided, licenses will be unassigned\
+            for MSP/tenant customers except the customers present in\
+            exclude_customers list, default=[]
         :type exclude_customers: list, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SUBSCRIPTIONS["UNASSIGN_LIC_MSP"]
@@ -246,23 +301,28 @@ class Subscriptions(object):
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
 
+
 class AutoLicense(object):
     """A python class to manage auto-licenses for Aruba Central
     """
+
     def disable_autolicensing_services(self, conn, services):
         """This function is used to disable auto licensing.
         Note: This API is not applicable for MSP customer
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["DISABLE_SVC"]
         data = {
-                "services": services
+            "services": services
         }
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
@@ -270,9 +330,11 @@ class AutoLicense(object):
     def get_autolicense_services(self, conn):
         """This function is used to get services which are auto enabled.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["GET_SVC"]
@@ -280,41 +342,53 @@ class AutoLicense(object):
         return resp
 
     def assign_autolicense_services(self, conn, services):
-        """This function is used to assign licenses to all devices for given services and enable auto licensing.
-        Note: This API is not applicable for MSP customer
+        """This function is used to assign licenses to all devices for given\
+            services and enable auto licensing. \n
+            Note: This API is not applicable for MSP customer
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["ASSIGN_LIC_SVC"]
         data = {
-                "services": services
+            "services": services
         }
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def disable_msp_autolicense_services(self, conn, services, include_customers=[], exclude_customers=[]):
-        """Disable auto license settings for MSP and Tenants for the given services. This will not change the current
+    def disable_msp_autolicense_services(self, conn, services,
+                                         include_customers=[],
+                                         exclude_customers=[]):
+        """Disable auto license settings for MSP and Tenants for the given\
+            services. This will not change the current
         license device mapping
 
-        Note: If include_customers and exclude_customers are not provided then auto license setting will be disabled
+        Note: If include_customers and exclude_customers are not provided then\
+            auto license setting will be disabled
         for all customers i.e MSP and tenants.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :param include_customers: if provided, licensing will be disable only for the customers present in
-            include_customers list, defaults to []
+        :param include_customers: if provided, licensing will be disable only\
+            for the customers present in include_customers list, defaults to []
         :type include_customers: list, optional
-        :param exclude_customers: if provided, licensing will be disabled for the customers except the customers
-            present in exclude_customers list, defaults to []
+        :param exclude_customers: if provided, licensing will be disabled for\
+            the customers except the customers present in exclude_customers\
+            list, defaults to []
         :type exclude_customers: list, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["DISABLE_LIC_SVC_MSP"]
@@ -331,11 +405,13 @@ class AutoLicense(object):
     def get_msp_autolicense_services(self, conn, customer_id: str):
         """[summary]
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param customer_id: Customer id of msp or tenant.
         :type customer_id: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["GET_LIC_SVC_MSP"]
@@ -345,27 +421,36 @@ class AutoLicense(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def assign_msp_autolicense_services(self, conn, services, include_customers=[], exclude_customers=[]):
-        """Enable auto license settings for MSP and Tenants. Assign licenses for given services to all the devices
-        owned by tenant customers. Note - License assignment is not supported for the MSP owned devices. License
-        assignment will be in paused state if the total license tokens are less than total device counts(including
-        MSP and tenants)
+    def assign_msp_autolicense_services(self, conn, services,
+                                        include_customers=[],
+                                        exclude_customers=[]):
+        """Enable auto license settings for MSP and Tenants. Assign licenses\
+        for given services to all the devices owned by tenant customers.\n
+        Note - License assignment is not supported for the MSP owned devices.\
+        License assignment will be in paused state if the total license tokens\
+        are less than total device counts(including MSP and tenants)
 
-        Note: If include_customers and exclude_customers are not provided then license settings will be enabled for
-        all customers i.e MSP, tenants and future tenants(Note: Newly created tenant will be inherited
+        Note: If include_customers and exclude_customers are not provided then\
+        license settings will be enabled for all customers i.e MSP, tenants\
+        and future tenants(Note: Newly created tenant will be inherited\
         license settings from MSP)
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param services: List of service names. Call services/config API to get the list of valid service names.
+        :param services: List of service names. Call services/config API to\
+            get the list of valid service names.
         :type services: list
-        :param include_customers: if provided, license settings will be enabled only for the customers present
+        :param include_customers: if provided, license settings will be\
+            enabled only for the customers present
             in include_customers list., defaults to []
         :type include_customers: list, optional
-        :param exclude_customers: if provided, license settings will be enabled for customers except the customers
-            present in exclude_customers list, defaults to []
+        :param exclude_customers: if provided, license settings will be\
+            enabled for customers except the customers present in\
+            exclude_customers list, defaults to []
         :type exclude_customers: list, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.AUTO_LICENSE["ASSIGN_LIC_SVC_MSP"]
@@ -379,19 +464,25 @@ class AutoLicense(object):
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-
     def get_license_status(self, conn, service_name: str):
-        """Get services and corresponding license token availability status. If True, license tokens are more than device
-        count else less than device count.(Note - Autolicense is in paused state when license tokens are
-        less than device count)
+        """Get services and corresponding license token availability status.\
+        If True, license tokens are more than device count else less than\
+        device count.(Note - Autolicense is in paused state when license\
+        tokens are less than device count)
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param service_name: Specific service name(dm/pa/..). Call services/config API to get the list of valid service names.
+        :param service_name: Specific service name(dm/pa/..). Call\
+            services/config API to get the list of valid service names.
         :type service_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = urlJoin(urls.AUTO_LICENSE["GET_SVC_LIC_TOK"], service_name, "status")
+        path = urlJoin(
+            urls.AUTO_LICENSE["GET_SVC_LIC_TOK"],
+            service_name,
+            "status")
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp

--- a/pycentral/monitoring.py
+++ b/pycentral/monitoring.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -27,23 +27,31 @@ from pycentral.base_utils import console_logger
 urls = MonitoringUrl()
 logger = console_logger("MONITORING")
 
+
 class Sites(object):
-    """A python class consisting of functions to manage Aruba Central Sites via REST API
+    """A python class consisting of functions to manage Aruba Central Sites\
+        via REST API
     """
-    def get_sites(self, conn, calculate_total=False, offset=0, limit=100, sort="+site_name"):
+
+    def get_sites(self, conn, calculate_total=False, offset=0, limit=100,
+                  sort="+site_name"):
         """Get list of sites
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param calculate_total: Whether to calculate total number of sites, defaults to False
+        :param calculate_total: Whether to calculate total number of sites,\
+            defaults to False
         :type calculate_total: bool, optional
         :param offset: Pagination offset, defaults to 0
         :type offset: int, optional
         :param limit: Pagination limit with Max 1000, defaults to 100
         :type limit: int, optional
-        :param sort: Sort list of sites based on one of '+site_name', '-site_name', defaults to "+site_name"
+        :param sort: Sort list of sites based on one of '+site_name',\
+            '-site_name', defaults to "+site_name"
         :type sort: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SITES["GET_ALL"]
@@ -59,7 +67,8 @@ class Sites(object):
     def create_site(self, conn, site_name, site_address={}, geolocation={}):
         """Creates a new site
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param site_name: Name of the site be created.
         :type site_name: str
@@ -70,34 +79,44 @@ class Sites(object):
             * keyword country: Country name string \n
             * keyword zipcode: Zipcode string \n
         :type site_address: dict, optional
-        :param geolocation: Mutually exclusive with site address. Provide either one option, defaults to {} \n
+        :param geolocation: Mutually exclusive with site address. Provide\
+            either one option, defaults to {} \n
             * keyword latitude: Site location latitude in the world map \n
             * keyword longitude: Site location longitude in the world map \n
         :type geolocation: dict, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SITES["CREATE"]
         if not site_address and not geolocation:
-            logger.error("Site {} Creation Error.. Pass Address OR Geolocation!".format(site_name))
+            logger.error(
+                "Site {} Creation Error.. \
+                    Pass Address OR Geolocation!".format(site_name))
             return None
 
         if site_address and geolocation:
-            logger.error("Site {} Creation Error.. Pass Address OR Geolocation, Not Both!".format(site_name))
+            logger.error(
+                "Site {} Creation Error.. Pass Address OR Geolocation,\
+                    Not Both!".format(site_name))
             return None
 
-        data = self._build_site_payload(site_name=site_name, site_address=site_address,
-                                        geolocation=geolocation)
+        data = self._build_site_payload(
+            site_name=site_name,
+            site_address=site_address,
+            geolocation=geolocation)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def update_site(self, conn, site_id, site_name, site_address={}, geolocation={}):
+    def update_site(self, conn, site_id, site_name, site_address={},
+                    geolocation={}):
         """Update/Modify an existing site
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
+        :param site_id: ID assigned by Aruba Central when the site is created.\
+            Can be obtained from find_site_id function.
         :type site_id: int
         :param site_name: Name of the site be created.
         :type site_name: str
@@ -108,98 +127,115 @@ class Sites(object):
             * keyword country: Country name string \n
             * keyword zipcode: Zipcode string \n
         :type site_address: dict, optional
-        :param geolocation: Mutually exclusive with site address. Provide either one option, defaults to {} \n
+        :param geolocation: Mutually exclusive with site address. Provide\
+            either one option, defaults to {} \n
             * keyword latitude: Site location latitude in the world map \n
             * keyword longitude: Site location longitude in the world map \n
         :type geolocation: dict, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.SITES["UPDATE"], str(site_id))
         if not site_address and not geolocation:
-            logger.error("Site {} Update Error.. Pass Address OR Geolocation!".format(site_name))
+            logger.error(
+                "Site {} Update Error.. \
+                    Pass Address OR Geolocation!".format(site_name))
             return None
 
         if site_address and geolocation:
-            logger.error("Site {} Update Error.. Pass Address OR Geolocation, Not Both!".format(site_name))
+            logger.error(
+                "Site {} Update Error.. Pass Address OR Geolocation, \
+                    Not Both!".format(site_name))
             return None
 
-        data = self._build_site_payload(site_name=site_name, site_address=site_address,
-                                        geolocation=geolocation)
+        data = self._build_site_payload(
+            site_name=site_name,
+            site_address=site_address,
+            geolocation=geolocation)
         resp = conn.command(apiMethod="PATCH", apiPath=path, apiData=data)
         return resp
 
     def delete_site(self, conn, site_id):
         """Delete an existing site
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
+        :param site_id: ID assigned by Aruba Central when the site is created.\
+            Can be obtained from find_site_id function.
         :type site_id: int
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.SITES["DELETE"], str(site_id))
         resp = conn.command(apiMethod="DELETE", apiPath=path)
         return resp
 
-    
     def associate_devices(self, conn, site_id, device_type, device_ids):
         """Associate multiple devices to a site
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
-            from find_site_id function.
+        :param site_id: ID assigned by Aruba Central when the site is created.\
+            Can be obtained from find_site_id function.
         :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :param device_type: Type of the device. One of the "IAP",\
+            "ArubaSwitch", "CX", "MobilityController".
         :type device_type: str
         :param device_ids: List of Aruba devices' serial number
         :type device_ids: list
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SITES["ADD_DEVICES"]
         if isinstance(device_ids, str):
             device_ids = [device_ids]
-        data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
-                                               device_ids=device_ids)
+        data = self._build_site_devices_payload(
+            site_id=site_id, device_type=device_type, device_ids=device_ids)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    
     def unassociate_devices(self, conn, site_id, device_type, device_ids):
         """Unassociate a device from a site
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
+        :param site_id: ID assigned by Aruba Central when the site is created.\
+            Can be obtained
             from find_site_id function.
         :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :param device_type: Type of the device. One of the "IAP",\
+            "ArubaSwitch", "CX", "MobilityController".
         :type device_type: str
         :param device_id: Aruba device serial number
         :type device_id: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.SITES["DELETE_DEVICES"]
         if isinstance(device_ids, str):
             device_ids = [device_ids]
-        data = self._build_site_devices_payload(site_id=site_id, device_type=device_type,
-                                               device_ids=device_ids)
+        data = self._build_site_devices_payload(
+            site_id=site_id, device_type=device_type, device_ids=device_ids)
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiData=data)
         return resp
 
     def find_site_id(self, conn, site_name):
         """Find site id from site name
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param site_name: Name of the site be created.
         :type site_name: str
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         max_limit_size = 1000
@@ -237,7 +273,8 @@ class Sites(object):
             * keyword country: Country name string \n
             * keyword zipcode: Zipcode string \n
         :type site_address: dict, optional
-        :param geolocation: Mutually exclusive with site address. Provide either one option, defaults to {} \n
+        :param geolocation: Mutually exclusive with site address. Provide\
+            either one option, defaults to {} \n
             * keyword latitude: Site location latitude in the world map \n
             * keyword longitude: Site location longitude in the world map \n
         :type geolocation: dict, optional
@@ -256,10 +293,12 @@ class Sites(object):
     def _build_site_devices_payload(self, site_id, device_type, device_ids):
         """HTTP payload for device(s) in a site
 
-        :param site_id: ID assigned by Aruba Central when the site is created. Can be obtained
+        :param site_id: ID assigned by Aruba Central when the site is created.\
+            Can be obtained
             from find_site_id function.
         :type site_id: int
-        :param device_type: Type of the device. One of the "IAP", "ArubaSwitch", "CX", "MobilityController".
+        :param device_type: Type of the device. One of the "IAP",\
+            "ArubaSwitch", "CX", "MobilityController".
         :type device_type: str
         :param device_ids: List of Aruba devices' serial number
         :type device_ids: list

--- a/pycentral/rapids.py
+++ b/pycentral/rapids.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -28,12 +28,15 @@ urls = RapidsUrl()
 class Rogues():
     """A Python class to obtain Aruba Central's Rougue details via REST APIs.
     """
-    def list_rogue_aps(self, conn, group=None, label=None, site=None, swarm_id=None,
-                       start=None, end=None, from_timestamp=None, to_timestamp=None,
-                       limit=100, offset=0):
+
+    def list_rogue_aps(self, conn, group=None, label=None, site=None,
+                       swarm_id=None, start=None, end=None,
+                       from_timestamp=None, to_timestamp=None, limit=100,
+                       offset=0):
         """Get rogue APs over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -43,24 +46,27 @@ class Rogues():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds.
             Default is current timestamp minus 3 hours, defaults to None
         :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
         :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
-            defaults to None
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.ROGUES["GET_ROGUE_AP"]
@@ -87,12 +93,14 @@ class Rogues():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def list_interfering_aps(self, conn, group=None, label=None, site=None, swarm_id=None,
-                             start=None, end=None, from_timestamp=None, to_timestamp=None,
-                             limit=100, offset=0):
+    def list_interfering_aps(self, conn, group=None, label=None, site=None,
+                             swarm_id=None, start=None, end=None,
+                             from_timestamp=None, to_timestamp=None, limit=100,
+                             offset=0):
         """Get interfering APs over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+        API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -102,24 +110,28 @@ class Rogues():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds.
             Default is current timestamp minus 3 hours, defaults to None
         :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds.
             Default is current timestamp, defaults to None
         :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
-            defaults to None
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in \
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.ROGUES["GET_INTERFERING_AP"]
@@ -146,12 +158,14 @@ class Rogues():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def list_suspect_aps(self, conn, group=None, label=None, site=None, swarm_id=None,
-                         start=None, end=None, from_timestamp=None, to_timestamp=None,
-                         limit=100, offset=0):
+    def list_suspect_aps(self, conn, group=None, label=None, site=None,
+                         swarm_id=None, start=None, end=None,
+                         from_timestamp=None, to_timestamp=None, limit=100,
+                         offset=0):
         """Get suspect APs over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -161,24 +175,27 @@ class Rogues():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp minus 3 hours, defaults to None
-        :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
-        :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds. Default is current timestamp minus 3 hours,\
             defaults to None
+        :type start: int, optional
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
+        :type end: int, optional
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.ROGUES["GET_SUSPECT_AP"]
@@ -205,12 +222,14 @@ class Rogues():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def list_neighbor_aps(self, conn, group=None, label=None, site=None, swarm_id=None,
-                          start=None, end=None, from_timestamp=None, to_timestamp=None,
-                          limit=100, offset=0):
+    def list_neighbor_aps(self, conn, group=None, label=None, site=None,
+                          swarm_id=None, start=None, end=None,
+                          from_timestamp=None, to_timestamp=None, limit=100,
+                          offset=0):
         """Get neighbor APs over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -220,24 +239,27 @@ class Rogues():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp minus 3 hours, defaults to None
-        :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
-        :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds. Default is current timestamp minus 3 hours,\
             defaults to None
+        :type start: int, optional
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
+        :type end: int, optional
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.ROGUES["GET_NEIGHBOR_AP"]
@@ -264,15 +286,20 @@ class Rogues():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
+
 class WIDS():
-    """A Python Class to obtain Aruba Central's Wireless Intrusion Detection details based on REST APIs.
+    """A Python Class to obtain Aruba Central's Wireless Intrusion Detection\
+        details based on REST APIs.
     """
-    def list_client_attacks(self, conn, group=None, label=None, site=None, swarm_id=None,
-                          start=None, end=None, from_timestamp=None, to_timestamp=None,
-                          limit=100, calculate_total=True, sort="-ts", offset=0):
+
+    def list_client_attacks(self, conn, group=None, label=None, site=None,
+                            swarm_id=None, start=None, end=None,
+                            from_timestamp=None, to_timestamp=None, limit=100,
+                            calculate_total=True, sort="-ts", offset=0):
         """Get client attacks over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -282,30 +309,35 @@ class WIDS():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp minus 3 hours, defaults to None
-        :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
-        :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds. Default is current timestamp minus 3 hours,\
             defaults to None
+        :type start: int, optional
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
+        :type end: int, optional
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
-        :param calculate_total: Whether to calculate total client attacks, defaults to True
+        :param calculate_total: Whether to calculate total client attacks,\
+            defaults to True
         :type calculate_total: bool, optional
-        :param sort: Sort parameter -ts(sort based on the timestamps in descending),
-            +ts(sort based on timestamps ascending), -macaddr(sort based on station mac descending)
-            and +macaddr(sort based station mac ascending), defaults to "-ts"
+        :param sort: Sort parameter -ts(sort based on the timestamps in\
+            descending), +ts(sort based on timestamps ascending), -macaddr\
+            (sort based on station mac descending) and +macaddr(sort based \
+            station mac ascending), defaults to "-ts"
         :type sort: str, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.WIDS["GET_CLIENT_ATTACKS"]
@@ -334,12 +366,16 @@ class WIDS():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def list_infrastructure_attacks(self, conn, group=None, label=None, site=None, swarm_id=None,
-                                    start=None, end=None, from_timestamp=None, to_timestamp=None,
-                                    limit=100, calculate_total=True, sort="-ts", offset=0):
+    def list_infrastructure_attacks(self, conn, group=None, label=None,
+                                    site=None, swarm_id=None, start=None,
+                                    end=None, from_timestamp=None,
+                                    to_timestamp=None, limit=100,
+                                    calculate_total=True, sort="-ts",
+                                    offset=0):
         """Get infrastructure attacks over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -349,30 +385,35 @@ class WIDS():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp minus 3 hours, defaults to None
-        :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
-        :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds. Default is current timestamp minus 3 hours,\
             defaults to None
+        :type start: int, optional
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
+        :type end: int, optional
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
-        :param calculate_total: Whether to calculate total client attacks, defaults to True
+        :param calculate_total: Whether to calculate total client attacks,\
+            defaults to True
         :type calculate_total: bool, optional
-        :param sort: Sort parameter -ts(sort based on the timestamps in descending),
-            +ts(sort based on timestamps ascending), -macaddr(sort based on station mac descending)
-            and +macaddr(sort based station mac ascending), defaults to "-ts"
+        :param sort: Sort parameter -ts(sort based on the timestamps in\
+            descending), +ts(sort based on timestamps ascending), -macaddr\
+            (sort based on station mac descending) and +macaddr(sort based\
+            station mac ascending), defaults to "-ts"
         :type sort: str, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.WIDS["GET_INFRA_ATTACKS"]
@@ -401,12 +442,14 @@ class WIDS():
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def list_wids_attacks(self, conn, group=None, label=None, site=None, swarm_id=None,
-                          start=None, end=None, from_timestamp=None, to_timestamp=None,
-                          limit=100, sort="-ts", offset=0):
+    def list_wids_attacks(self, conn, group=None, label=None, site=None,
+                          swarm_id=None, start=None, end=None,
+                          from_timestamp=None, to_timestamp=None, limit=100,
+                          sort="-ts", offset=0):
         """Get WIDS events over a time period
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param group: List of group names, defaults to None
         :type group: list, optional
@@ -416,28 +459,32 @@ class WIDS():
         :type site: list, optional
         :param swarm_id: Filter by Swarm ID, defaults to None
         :type swarm_id: str, optional
-        :param start: Need information from this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp minus 3 hours, defaults to None
-        :type start: int, optional
-        :param end: Need information to this timestamp. Timestamp is epoch in milliseconds.
-            Default is current timestamp, defaults to None
-        :type end: int, optional
-        :param from_timestamp: This parameter supercedes start parameter. Need information from this
-            timestamp. Timestamp is epoch in seconds. Default is current UTC timestamp minus 3 hours,
+        :param start: Need information from this timestamp. Timestamp is epoch\
+            in milliseconds. Default is current timestamp minus 3 hours,\
             defaults to None
+        :type start: int, optional
+        :param end: Need information to this timestamp. Timestamp is epoch in\
+            milliseconds. Default is current timestamp, defaults to None
+        :type end: int, optional
+        :param from_timestamp: This parameter supercedes start parameter. Need\
+            information from this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp minus 3 hours, defaults to None
         :type from_timestamp: int, optional
-        :param to_timestamp: This parameter supercedes end parameter. Need information to this timestamp.
-            Timestamp is epoch in seconds. Default is current UTC timestamp, defaults to None
+        :param to_timestamp: This parameter supercedes end parameter. Need\
+            information to this timestamp. Timestamp is epoch in seconds.\
+            Default is current UTC timestamp, defaults to None
         :type to_timestamp: int, optional
         :param limit: pagination size (default = 100), defaults to 100
         :type limit: int, optional
-        :param sort: Sort parameter -ts(sort based on the timestamps in descending),
-            +ts(sort based on timestamps ascending), -macaddr(sort based on station mac descending)
-            and +macaddr(sort based station mac ascending), defaults to "-ts"
+        :param sort: Sort parameter -ts(sort based on the timestamps in\
+            descending), +ts(sort based on timestamps ascending), -macaddr\
+            (sort based on station mac descending) and +macaddr(sort based\
+            station mac ascending), defaults to "-ts"
         :type sort: str, optional
         :param offset: Pagination offset (default = 0), defaults to 0
         :type offset: int, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.WIDS["GET_WIDS_EVENTS"]

--- a/pycentral/refresh_api_token.py
+++ b/pycentral/refresh_api_token.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,23 +25,30 @@ from pycentral.base_utils import console_logger
 
 urls = RefreshUrl()
 
+
 class RefreshApiToken(object):
     """Refresh the API access token in API Gateway using OAUTH API
     """
-    def refresh_token(self, conn, apigw_client_id, apigw_client_secret, old_refresh_token):
-        """This function refreshes the existing access token and replaces old token with new token.
-        The returned token dict will contain both access and refresh token. Use refresh token provided
-        in the return dict for next refresh.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+    def refresh_token(self, conn, apigw_client_id, apigw_client_secret,
+                      old_refresh_token):
+        """This function refreshes the existing access token and replaces old\
+        token with new token. The returned token dict will contain both access\
+        and refresh token. Use refresh token provided in the return dict for\
+        next refresh.
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param apigw_client_id: Client ID from API Gateway page
         :type apigw_client_id: str
         :param apigw_client_secret: Client Secret from API Gateway page
         :type apigw_client_secret: str
-        :param old_refresh_token: Refresh token value from the current/expired API token.
+        :param old_refresh_token: Refresh token value from the current/expired\
+            API token.
         :type old_refresh_token: str
-        :return: Refrehed token dict consisting of access_token and refresh_token.
+        :return: Refrehed token dict consisting of access_token and\
+            refresh_token.
         :rtype: dict
         """
         path = urls.REFRESH_TOKEN["REFRESH"]
@@ -52,5 +59,9 @@ class RefreshApiToken(object):
             "grant_type": "refresh_token",
             "refresh_token": old_refresh_token
         }
-        resp = conn.command(apiMethod="POST", apiPath=path, apiParams=params, retry_api_call=False)
+        resp = conn.command(
+            apiMethod="POST",
+            apiPath=path,
+            apiParams=params,
+            retry_api_call=False)
         return resp

--- a/pycentral/topology.py
+++ b/pycentral/topology.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -24,17 +24,23 @@ from pycentral.url_utils import TopoUrl, urlJoin
 from pycentral.base_utils import console_logger
 urls = TopoUrl()
 
-class Topology():
-    """A python class to obtain Aruba Central Site's topology details via REST APIs.
-    """
-    def get_topology(self, conn, site_id):
-        """Get topology details of a site. The input is the id corresponding to a label or a site.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+class Topology():
+    """A python class to obtain Aruba Central Site's topology details via REST\
+        APIs.
+    """
+
+    def get_topology(self, conn, site_id):
+        """Get topology details of a site. The input is the id corresponding\
+        to a label or a site.
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param site_id: Site ID
         :type site_id: int
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TOPOLOGY["GET_TOPO_SITE"], str(site_id))
@@ -45,11 +51,13 @@ class Topology():
     def get_device_details(self, conn, device_serial):
         """Provides details of a device when serial number is passed as input.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Device Serial Number
         :type device_serial: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TOPOLOGY["GET_DEVICES"], device_serial)
@@ -57,16 +65,18 @@ class Topology():
         return resp
 
     def get_edge_details(self, conn, source_serial, dest_serial):
-        """Get details of an edge grouped by lagname. The serials of nodes/devices on both
-        sides of the edge should passed as input.
+        """Get details of an edge grouped by lagname. The serials of\
+        nodes/devices on both sides of the edge should passed as input.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param source_serial: Device serial number.
         :type source_serial: str
         :param dest_serial: Device serial number.
         :type dest_serial: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TOPOLOGY["GET_EDGES"], source_serial, dest_serial)
@@ -74,33 +84,41 @@ class Topology():
         return resp
 
     def get_uplink_details(self, conn, source_serial, uplink_id):
-        """Get details of an uplink. The serials of node/device on one side of the uplink and the
-        uplink id of the uplink should passed as input. Desired uplink id can be found in get
+        """Get details of an uplink. The serials of node/device on one side of\
+        the uplink and the uplink id of the uplink should passed as input.\
+Desired uplink id can be found in get
         topology details api.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param source_serial: Device serial number.
+        :param source_serial: Device serial number.xx
         :type source_serial: str
         :param uplink_id: Uplink id.
         :type uplink_id: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = urlJoin(urls.TOPOLOGY["GET_UPLINK"], source_serial, str(uplink_id))
+        path = urlJoin(
+            urls.TOPOLOGY["GET_UPLINK"],
+            source_serial,
+            str(uplink_id))
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
     def tunnel_details(self, conn, site_id, tunnel_map_names):
         """Get tunnel details.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param site_id: Site ID
         :type site_id: int
         :param tunnel_map_names: Comma separated list of tunnel map names.
         :type tunnel_map_names: list
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TOPOLOGY["GET_TUNNEL"], str(site_id))
@@ -112,11 +130,13 @@ class Topology():
     def ap_lldp_neighbors(self, conn, device_serial):
         """Get neighbor details reported by AP via LLDP.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param device_serial: Device serial number.
         :type device_serial: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.TOPOLOGY["GET_AP_LLDP"], device_serial)

--- a/pycentral/url_utils.py
+++ b/pycentral/url_utils.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,7 +22,9 @@
 
 def urlJoin(*args):
     trailing_slash = '/' if args[-1].endswith('/') else ''
-    return "/" + "/".join(map(lambda x: str(x).strip('/'), args)) + trailing_slash
+    return "/" + "/".join(map(lambda x: str(x).strip('/'),
+                          args)) + trailing_slash
+
 
 class RefreshUrl(object):
     REFRESH_TOKEN = {
@@ -98,19 +100,24 @@ class LicensingUrl():
         "GET_LIC_SVC": "/platform/licensing/v1/services/config",
         "UNASSIGN_LIC": "/platform/licensing/v1/subscriptions/devices/all",
         "ASSIGN_LIC": "/platform/licensing/v1/subscriptions/devices/all",
-        "UNASSIGN_LIC_MSP": "/platform/licensing/v1/msp/subscriptions/devices/all",
-        "ASSIGN_LIC_MSP": "/platform/licensing/v1/msp/subscriptions/devices/all"
-    }
+        "UNASSIGN_LIC_MSP":
+            "/platform/licensing/v1/msp/subscriptions/devices/all",
+        "ASSIGN_LIC_MSP":
+            "/platform/licensing/v1/msp/subscriptions/devices/all"}
 
     AUTO_LICENSE = {
         "GET_SVC": "/platform/licensing/v1/customer/settings/autolicense",
         "DISABLE_SVC": "/platform/licensing/v1/customer/settings/autolicense",
-        "ASSIGN_LIC_SVC": "/platform/licensing/v1/customer/settings/autolicense",
-        "DISABLE_LIC_SVC_MSP": "/platform/licensing/v1/msp/customer/settings/autolicense",
-        "GET_LIC_SVC_MSP": "/platform/licensing/v1/msp/customer/settings/autolicense",
-        "ASSIGN_LIC_SVC_MSP": "/platform/licensing/v1/msp/customer/settings/autolicense",
-        "GET_SVC_LIC_TOK": "/platform/licensing/v1/autolicensing/services"
-    }
+        "ASSIGN_LIC_SVC":
+            "/platform/licensing/v1/customer/settings/autolicense",
+        "DISABLE_LIC_SVC_MSP":
+            "/platform/licensing/v1/msp/customer/settings/autolicense",
+        "GET_LIC_SVC_MSP":
+            "/platform/licensing/v1/msp/customer/settings/autolicense",
+        "ASSIGN_LIC_SVC_MSP":
+            "/platform/licensing/v1/msp/customer/settings/autolicense",
+        "GET_SVC_LIC_TOK": "/platform/licensing/v1/autolicensing/services"}
+
 
 class UserManagementUrl():
     USERS = {
@@ -130,6 +137,7 @@ class UserManagementUrl():
         "DELETE": "/platform/rbac/v1/apps"
     }
 
+
 class FirmwareManagementUrl():
     FIRMWARE = {
         "GET_ALL_SWARMS": "/firmware/v1/swarms",
@@ -141,6 +149,7 @@ class FirmwareManagementUrl():
         "CANCEL": "/firmware/v1/upgrade/cancel"
     }
 
+
 class TopoUrl():
     TOPOLOGY = {
         "GET_TOPO_SITE": "/topology_external_api",
@@ -150,6 +159,7 @@ class TopoUrl():
         "GET_TUNNEL": "/topology_external_api/tunnels",
         "GET_AP_LLDP": "/topology_external_api/apNeighbors"
     }
+
 
 class RapidsUrl():
     ROGUES = {
@@ -165,6 +175,7 @@ class RapidsUrl():
         "GET_WIDS_EVENTS": "/rapids/v1/wids/events"
     }
 
+
 class AuditUrl():
     TRAIL_LOG = {
         "GET_ALL": "/platform/auditlogs/v1/logs",
@@ -175,6 +186,7 @@ class AuditUrl():
         "GET_ALL": "/auditlogs/v1/events",
         "GET": "/auditlogs/v1/event_details"
     }
+
 
 class VisualrfUrl():
     CLIENT_LOCATION = {
@@ -196,6 +208,7 @@ class VisualrfUrl():
         "GET_FLOOR_APS": "/visualrf_api/v1/floor",
         "GET_AP_LOC": "/visualrf_api/v1/access_point_location"
     }
+
 
 class MonitoringUrl():
     SITES = {

--- a/pycentral/user_management.py
+++ b/pycentral/user_management.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,24 +25,30 @@ from pycentral.base_utils import console_logger
 
 urls = UserManagementUrl()
 
+
 class Users(object):
     """A Python class to manage Aruba Central Users via REST APIs.
     """
-    def list_users(self, conn, limit=20, offset=0, sort="+timestamp", email=None):
+
+    def list_users(self, conn, limit=20, offset=0, sort="+timestamp",
+                   email=None):
         """(This API will be deprecated in future release). Use get_users().
         Returns all users from the system associated to user's account
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param limit: Maximum number of items to return, defaults to 20
         :type limit: int, optional
         :param offset: Zero based offset to start from, defaults to 0
         :type offset: int, optional
-        :param sort: Sort ordering. One if +timestamp/-timestamp/+username/-username, defaults to "+timestamp"
+        :param sort: Sort ordering. One if +timestamp/-timestamp/+username/\
+            -username, defaults to "+timestamp"
         :type sort: str, optional
         :param email: Filter users by email, defaults to None
         :type email: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.USERS["LIST"]
@@ -57,25 +63,30 @@ class Users(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_users(self, conn, limit=20, offset=0, order_by="+username", app_name=None, user_type=None, status=None):
+    def get_users(self, conn, limit=20, offset=0, order_by="+username",
+                  app_name=None, user_type=None, status=None):
         """Returns all users from the system associated to user's account
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param limit: Maximum number of items to return, defaults to 20
         :type limit: int, optional
         :param offset: Zero based offset to start from, defaults to 0
         :type offset: int, optional
-        :param order_by: Sort ordering (ascending or descending). +username signifies ascending
-            order of username., defaults to "+username"
+        :param order_by: Sort ordering (ascending or descending). +username\
+            signifies ascending order of username., defaults to "+username"
         :type order_by: str, optional
         :param app_name: Filter users based on app_name, defaults to None
         :type app_name: str, optional
-        :param user_type: Filter based on system or federated user, defaults to None
+        :param user_type: Filter based on system or federated user, defaults\
+            to None
         :type user_type: str, optional
-        :param status: Filter user based on status (inprogress, failed), defaults to None
+        :param status: Filter user based on status (inprogress, failed),\
+            defaults to None
         :type status: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.USERS["GET_USERS"]
@@ -97,13 +108,15 @@ class Users(object):
     def get_user(self, conn, username, system_user=True):
         """Get user account details specified by user email
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param username: User's email id is specified as the user id
         :type username: str
         :param system_user: false if federated user, defaults to True
         :type system_user: bool, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.USERS["GET"], username)
@@ -113,28 +126,33 @@ class Users(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def _build_user(self, username, description, name, phone, address, applications, password=None):
-        """Internal function to build the JSON payload which is required to create/update users.
+    def _build_user(self, username, description, name, phone, address,
+                    applications, password=None):
+        """Internal function to build the JSON payload which is required to\
+        create/update users.
 
         :param username: User's email id is specified as the user id
         :type username: str
         :param description: description of user
         :type description: str
-        :param name: A dict containing 'firstname' and 'lastname' key value pairs.
+        :param name: A dict containing 'firstname' and 'lastname' key value\
+            pairs.
         :type name: dict
         :param phone: Phone number. Format: +country_code-local_number
         :type phone: str
-        :param address: Address of the user in dict format containing 'street', 'city', 'state',
-            'country' and 'zipcode'.
+        :param address: Address of the user in dict format containing\
+            'street', 'city', 'state', 'country' and 'zipcode'.
         :type address: dict
-        :param applications: List of dictionaries. Each element containing a dict to represent 'name',
-            and 'info' of the application for which the user will be granted access. 'info' is a dict
-            with 'role', 'tenant_role' and 'scope' keys. With 'scope' containing 'groups' key with
-            value as a list of groups.
+        :param applications: List of dictionaries. Each element containing a\
+            dict to represent 'name', and 'info' of the application for which\
+            the user will be granted access. 'info' is a dict with 'role', \
+            'tenant_role' and 'scope' keys. With 'scope' containing 'groups'\
+            key with value as a list of groups.
         :type applications: list
         :param password: password of user account, defaults to None
         :type password: str, optional
-        :return: Constructed paylod in dict format to be used for POST/PATCH of rbac user account.
+        :return: Constructed paylod in dict format to be used for POST/PATCH\
+            of rbac user account.
         :rtype: dict
         """
         payload = {
@@ -149,15 +167,17 @@ class Users(object):
             payload["password"] = password
         return payload
 
-    def create_user(self, conn, username:str, password:str, description: str,
-                    name: dict, phone:str, address:dict, applications:dict):
-        """Create a user account. For public cloud environment, user has to re-register via invitation
-        email. Email will be sent during processing of this request. Providing role on account setting
-        app is mandatory in this API along with other subscribed apps. Scope must be given only for
-        NMS app. For non-nms apps such as account setting refer the parameters in the example json
-        payload.
+    def create_user(self, conn, username: str, password: str, description: str,
+                    name: dict, phone: str, address: dict, applications: dict):
+        """Create a user account. For public cloud environment, user has to\
+        re-register via invitation email. Email will be sent during processing\
+        of this request. Providing role on account setting app is mandatory in\
+        this API along with other subscribed apps. Scope must be given only\
+        for NMS app. For non-nms apps such as account setting refer the\
+        parameters in the example json payload.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param username: User's email id is specified as the user id
         :type username: str
@@ -169,30 +189,42 @@ class Users(object):
         :type name: dict
         :param phone: Phone number. Format: +country_code-local_number
         :type phone: str
-        :param address: Address of the user. Dict containing 'street', 'city', 'state', 'country'
-            and 'zipcode'.
+        :param address: Address of the user. Dict containing 'street', 'city',\
+            'state', 'country' and 'zipcode'.
         :type address: dict
         :param applications: Define applications that needs access. \n
-            * keyword name: Name of the application. Example: 'nms', 'account_setting', etc. \n
-            * keyword info:  A list of dictionaries. Each element containing 'role', 'tenant_role',
-                and 'scope'. Where 'scope' contains 'groups' key with list of groups. \n
+            * keyword name: Name of the application. Example: 'nms',\
+                'account_setting', etc. \n
+            * keyword info:  A list of dictionaries. Each element containing\
+                'role', 'tenant_role', and 'scope'. Where 'scope' contains\
+                'groups' key with list of groups. \n
         :type applications: dict
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.USERS["CREATE"]
-        data = self._build_user(username, description, name, phone, address, applications, password)
+        data = self._build_user(
+            username,
+            description,
+            name,
+            phone,
+            address,
+            applications,
+            password)
         resp = conn.command(apiMethod="POST", apiPath=path, apiData=data)
         return resp
 
-    def update_user(self, conn, username:str, description: str,
-                    name: dict, phone:str, address:dict, applications:dict):
-        """Update user account details specified by user id. Providing info on account setting app
-        is mandatory in this API along with other subscribed apps.Scope must be given only for NMS
-        app. For non-nms apps such as account setting refer the parameters in the example json
+    def update_user(self, conn, username: str, description: str,
+                    name: dict, phone: str, address: dict, applications: dict):
+        """Update user account details specified by user id. Providing info on\
+        account setting app is mandatory in this API along with other\
+        subscribed apps.Scope must be given only for NMS app. For non-nms apps\
+        such as account setting refer the parameters in the example json\
         payload.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param username: User's email id is specified as the user id
         :type username: str
@@ -202,32 +234,43 @@ class Users(object):
         :type name: dict
         :param phone: Phone number. Format: +country_code-local_number
         :type phone: str
-        :param address: Address of the user. Dict containing 'street', 'city', 'state', 'country'
-            and 'zipcode'.
+        :param address: Address of the user. Dict containing 'street', 'city',\
+            'state', 'country' and 'zipcode'.
         :type address: dict
         :param applications: Define applications that needs access. \n
-            * keyword name: Name of the application. Example: 'nms', 'account_setting', etc. \n
-            * keyword info:  A list of dictionaries. Each element containing 'role', 'tenant_role',
-                and 'scope'. Where 'scope' contains 'groups' key with list of groups. \n
+            * keyword name: Name of the application. Example: 'nms',\
+                'account_setting', etc. \n
+            * keyword info:  A list of dictionaries. Each element containing\
+                'role', 'tenant_role', and 'scope'. Where 'scope' contains\
+                'groups' key with list of groups. \n
         :type applications: dict
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.USERS["UPDATE"], username)
-        data = self._build_user(username, description, name, phone, address, applications)
+        data = self._build_user(
+            username,
+            description,
+            name,
+            phone,
+            address,
+            applications)
         resp = conn.command(apiMethod="PATCH", apiPath=path, apiData=data)
         return resp
 
     def delete_user(self, conn, username, system_user=True):
         """Delete user account details specified by user id
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param username: User's email id is specified as the user id
         :type username: str
         :param system_user: false if federated user, defaults to True
         :type system_user: bool, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.USERS["DELETE"], username)
@@ -237,13 +280,17 @@ class Users(object):
         resp = conn.command(apiMethod="DELETE", apiPath=path, apiParams=params)
         return resp
 
+
 class Roles(object):
     """A Python class to manage Aruba Central User Roles via REST APIs.
     """
-    def get_user_roles(self, conn, app_name=None, limit=20, offset=0, order_by="+rolename"):
+
+    def get_user_roles(self, conn, app_name=None, limit=20, offset=0,
+                       order_by="+rolename"):
         """Get list of all roles
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param app_name: Filter users based on app_name, defaults to None
         :type app_name: str, optional
@@ -251,9 +298,11 @@ class Roles(object):
         :type limit: int, optional
         :param offset: Zero based offset to start from, defaults to 0
         :type offset: int, optional
-        :param order_by: Sort ordering. +rolename means ascending order of rolename, defaults to "+rolename"
+        :param order_by: Sort ordering. +rolename means ascending order of\
+            rolename, defaults to "+rolename"
         :type order_by: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.ROLES["GET_ROLES"]
@@ -267,24 +316,30 @@ class Roles(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def create_user_role(self, conn, app_name, rolename, applications, permission="modify"):
+    def create_user_role(self, conn, app_name, rolename, applications,
+                         permission="modify"):
         """Create an user role in an app
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param app_name: app name where role needs to be created
         :type app_name: str
         :param rolename: name of the role
         :type rolename: str
-        :param applications: List of dict. Each element containing the following structure. \n
-            * keyword appname: Name of the application. Example: 'nms', 'account_setting', etc. \n
-            * keyword modules:  A list of dictionaries. Each element containing 'module_name'
+        :param applications: List of dict. Each element containing the\
+            following structure. \n
+            * keyword appname: Name of the application. Example: 'nms',\
+                'account_setting', etc. \n
+            * keyword modules:  A list of dictionaries. Each element\
+                containing 'module_name'
                 and 'permission' for the modules. \n
             * keyword permission: permission for the app \n
         :type applications: dict
         :param permission: permission of the role, defaults to "modify"
         :type permission: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROLES["CREATE"], app_name, "roles")
@@ -299,13 +354,15 @@ class Roles(object):
     def delete_user_role(self, conn, app_name, rolename):
         """Delete a role specified by role name
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param app_name: app name
         :type app_name: str
         :param rolename: User role name
         :type rolename: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROLES["DELETE"], app_name, "roles", rolename)
@@ -315,37 +372,49 @@ class Roles(object):
     def get_user_role(self, conn, app_name, rolename):
         """Get Role details
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+             API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param app_name: app name
         :type app_name: str
         :param rolename: User role name
         :type rolename: str
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROLES["GET"], app_name, "roles", rolename)
         resp = conn.command(apiMethod="GET", apiPath=path)
         return resp
 
-    def update_user_role(self, conn, app_name, rolename, applications, permission="modify"):
+    def update_user_role(
+            self,
+            conn,
+            app_name,
+            rolename,
+            applications,
+            permission="modify"):
         """Update a role specified by role name
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param app_name: app name
         :type app_name: str
         :param rolename: User role name
         :type rolename: str
-        :param applications: List of dict. Each element containing the following structure. \n
-            * keyword appname: Name of the application. Example: 'nms', 'account_setting', etc. \n
-            * keyword modules:  A list of dictionaries. Each element containing 'module_name'
-                and 'permission' for the modules. \n
+        :param applications: List of dict. Each element containing the\
+            following structure. \n
+            * keyword appname: Name of the application. Example: 'nms',\
+                'account_setting', etc. \n
+            * keyword modules:  A list of dictionaries. Each element\
+                containing 'module_name' and 'permission' for the modules. \n
             * keyword permission: permission for the app \n
         :type applications: dict
         :param permission: [description], defaults to "modify"
         :type permission: str, optional
-        :return: HTTP Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: HTTP Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROLES["GET"], app_name, "roles", rolename)

--- a/pycentral/visualrf.py
+++ b/pycentral/visualrf.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,16 +25,21 @@ from pycentral.base_utils import console_logger
 
 urls = VisualrfUrl()
 
+
 class ClientLocation(object):
     """A python class to obtain client location based on visualRF floor map.
     """
-    def get_client_location(self, conn, macaddr: str, offset=0, limit=100, units="FEET"):
-        """Get location of a client. This function provides output only when visualRF is
-        configured in Aruba Central.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+    def get_client_location(self, conn, macaddr: str, offset=0, limit=100,
+                            units="FEET"):
+        """Get location of a client. This function provides output only when\
+            visualRF is configured in Aruba Central.
+
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param macaddr: Provide a macaddr of a client. For example "ac:bb:cc:dd:ec:10"
+        :param macaddr: Provide a macaddr of a client. For example\
+            "ac:bb:cc:dd:ec:10"
         :type macaddr: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -42,7 +47,8 @@ class ClientLocation(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.CLIENT_LOCATION["GET_CLIENT_LOC"], macaddr)
@@ -54,13 +60,15 @@ class ClientLocation(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_floor_clients(self, conn, floor_id: str, offset=0, limit=100, units="FEET"):
+    def get_floor_clients(self, conn, floor_id: str, offset=0, limit=100,
+                          units="FEET"):
         """Get location of clients within a floormap in Aruba Central visualRF.
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param floor_id: Provide floor_id returned by `get_building_floors()` function in
-            class:`FloorPlan`
+        :param floor_id: Provide floor_id returned by `get_building_floors()`\
+            function in class:`FloorPlan`
         :type floor_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -68,10 +76,14 @@ class ClientLocation(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = urlJoin(urls.CLIENT_LOCATION["GET_FLOOR_CLIENTS"], floor_id, "client_location")
+        path = urlJoin(
+            urls.CLIENT_LOCATION["GET_FLOOR_CLIENTS"],
+            floor_id,
+            "client_location")
         params = {
             "offset": offset,
             "limit": limit,
@@ -80,13 +92,17 @@ class ClientLocation(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
+
 class RougueLocation(object):
     """A python class to obtain location of rogue access points
     """
-    def get_rogueap_location(self, conn, macaddr: str, offset=0, limit=100, units="FEET"):
+
+    def get_rogueap_location(self, conn, macaddr: str, offset=0, limit=100,
+                             units="FEET"):
         """Get location of rogue a access point based on its Mac Address
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+             API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param macaddr: Provide Mac Address of an Access Point
         :type macaddr: str
@@ -96,7 +112,8 @@ class RougueLocation(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROGUE_LOCATION["GET_AP_LOC"], macaddr)
@@ -108,13 +125,15 @@ class RougueLocation(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_floor_rogueaps(self, conn, floor_id: str, offset=0, limit=100, units="FEET"):
+    def get_floor_rogueaps(self, conn, floor_id: str, offset=0, limit=100,
+                           units="FEET"):
         """Get rogue access points within a floor
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param floor_id: Provide floor id. Can be obtained from `get_building_floors()` within
-            class:`FloorPlan`
+        :param floor_id: Provide floor id. Can be obtained from\
+            `get_building_floors()` within class:`FloorPlan`
         :type floor_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -122,7 +141,8 @@ class RougueLocation(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.ROGUE_LOCATION["GET_FLOOR_APS"], floor_id)
@@ -134,19 +154,24 @@ class RougueLocation(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
+
 class FloorPlan(object):
-    """A Python class to obtain information of floorplan in Aruba Central visualRF.
+    """A Python class to obtain information of floorplan in Aruba Central\
+        visualRF.
     """
+
     def get_campus_list(self, conn, offset=0, limit=100):
         """Get list of campuses in visualRF floorplan
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
         :param limit: Pagination size. Default 100 Max 100, defaults to 100
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urls.FLOOR_PLAN["GET_CAMPUS_LIST"]
@@ -160,16 +185,18 @@ class FloorPlan(object):
     def get_campus_buildings(self, conn, campus_id: str, offset=0, limit=100):
         """Get campus info and buildings within the campus
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param campus_id: Provide campus id. Can be obtained from `get_campus_list` function in
-            class:`FloorPlan`
+        :param campus_id: Provide campus id. Can be obtained from\
+            `get_campus_list` function in class:`FloorPlan`
         :type campus_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
         :param limit: Pagination size. Default 100 Max 100, defaults to 100
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FLOOR_PLAN["GET_CAMPUS_INFO"], campus_id)
@@ -180,13 +207,15 @@ class FloorPlan(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_building_floors(self, conn, building_id: str, offset=0, limit=100, units="FEET"):
+    def get_building_floors(self, conn, building_id: str, offset=0, limit=100,
+                            units="FEET"):
         """Get building info and floors within the building
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param building_id: Provide building id. Can be obtained from `get_campus_buildings` within
-            class:`FloorPlan`
+        :param building_id: Provide building id. Can be obtained from\
+            `get_campus_buildings` within class:`FloorPlan`
         :type building_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -194,7 +223,8 @@ class FloorPlan(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FLOOR_PLAN["GET_BUILDING_INFO"], building_id)
@@ -206,13 +236,15 @@ class FloorPlan(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_floor_info(self, conn, floor_id: str, offset=0, limit=100, units="FEET"):
+    def get_floor_info(self, conn, floor_id: str, offset=0, limit=100,
+                       units="FEET"):
         """Get floor information
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param floor_id: Provide floor id. Can be obtained from `get_building_floors()` within
-            class:`FloorPlan`
+        :param floor_id: Provide floor id. Can be obtained from\
+            `get_building_floors()` within class:`FloorPlan`
         :type floor_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -220,7 +252,8 @@ class FloorPlan(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FLOOR_PLAN["GET_FLOOR_INFO"], floor_id)
@@ -235,16 +268,18 @@ class FloorPlan(object):
     def get_floor_image(self, conn, floor_id, offset=0, limit=100):
         """Get Floor's background image in base64 format
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param floor_id: Provide floor id. Can be obtained from `get_building_floors()` within
-            class:`FloorPlan`
+        :param floor_id: Provide floor id. Can be obtained from\
+            `get_building_floors()` within class:`FloorPlan`
         :type floor_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
         :param limit: Pagination size. Default 100 Max 100, defaults to 100
         :type limit: int, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FLOOR_PLAN["GET_FLOOR_IMG"], floor_id, "image")
@@ -258,10 +293,11 @@ class FloorPlan(object):
     def get_floor_aps(self, conn, floor_id, offset=0, limit=100, units="FEET"):
         """Get access points within a floor
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param floor_id: Provide floor id. Can be obtained from `get_building_floors()` within
-            class:`FloorPlan`
+        :param floor_id: Provide floor id. Can be obtained from\
+            `get_building_floors()` within class:`FloorPlan`
         :type floor_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -269,10 +305,14 @@ class FloorPlan(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
-        path = urlJoin(urls.FLOOR_PLAN["GET_FLOOR_APS"], floor_id, "access_point_location")
+        path = urlJoin(
+            urls.FLOOR_PLAN["GET_FLOOR_APS"],
+            floor_id,
+            "access_point_location")
         params = {
             "offset": offset,
             "limit": limit,
@@ -281,12 +321,15 @@ class FloorPlan(object):
         resp = conn.command(apiMethod="GET", apiPath=path, apiParams=params)
         return resp
 
-    def get_ap_location(self, conn, ap_id: str, offset=0, limit=100, units="FEET"):
+    def get_ap_location(self, conn, ap_id: str, offset=0, limit=100,
+                        units="FEET"):
         """Get location of an access point within a floorplan
 
-        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an API call.
+        :param conn: Instance of class:`pycentral.ArubaCentralBase` to make an\
+            API call.
         :type conn: class:`pycentral.ArubaCentralBase`
-        :param ap_id: Provide ap_id returned by `get_floor_aps()` within class:`FloorPlan`
+        :param ap_id: Provide ap_id returned by `get_floor_aps()` within\
+            class:`FloorPlan`
         :type ap_id: str
         :param offset: Pagination start index., defaults to 0
         :type offset: int, optional
@@ -294,7 +337,8 @@ class FloorPlan(object):
         :type limit: int, optional
         :param units: METERS or FEET, defaults to "FEET"
         :type units: str, optional
-        :return: Response as provided by 'command' function in class:`pycentral.ArubaCentralBase`
+        :return: Response as provided by 'command' function in\
+            class:`pycentral.ArubaCentralBase`
         :rtype: dict
         """
         path = urlJoin(urls.FLOOR_PLAN["GET_AP_LOC"], ap_id)

--- a/pycentral/workflows/workflows_utils.py
+++ b/pycentral/workflows/workflows_utils.py
@@ -9,8 +9,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -20,20 +20,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys, os
-import json, yaml, csv
+import sys
+import os
+import json
+import yaml
+import csv
 
 from pycentral.base import ArubaCentralBase
 
+
 def get_file_contents(filename, logger=None):
-    """Function to open a JSON/YAML/CSV file and return the contents of the file in dict format. (A list of dict is
-        returned for a CSV file.)
+    """Function to open a JSON/YAML/CSV file and return the contents of the\
+        file in dict format. (A list of dict is returned for a CSV file.)
 
     :param filename: Name of an existing JSON/YAML/CSV file.
     :type filename: str
     :param logger: Provide an instance of class:`logging.logger`.
     :type logger: class:`logging.logger`, optional
-    :raises UserWarning: Raises warning when supported filetypes are not provided.
+    :raises UserWarning: Raises warning when supported filetypes are not\
+        provided.
     :return: Data loaded from JSON/YAML/CSV file
     :rtype: dict (a list of dict for CSV)
     """
@@ -62,12 +67,14 @@ def get_file_contents(filename, logger=None):
         else:
             print(str(err))
 
+
 def dict_list_to_csv(filename, csv_data_list, logger=None):
     """Write list of dictionaries into a CSV File via csv.DictWriter()
 
     :param filename: Name of the file to be created or overwritten
     :type filename: str
-    :param csv_data_list: A list of dictionaries, where each dict is a row in CSV file
+    :param csv_data_list: A list of dictionaries, where each dict is a row in\
+        CSV file
     :type csv_data_list: list
     :param logger: Provide an instance of class:`logging.logger`.
     :type logger: class:`logging.logger`, optional
@@ -86,7 +93,9 @@ def dict_list_to_csv(filename, csv_data_list, logger=None):
             for data in csv_data_list:
                 writer.writerow(data)
         if logger:
-            logger.info("Creating a new csv file '%s' with failed APs..." % filename)
+            logger.info(
+                "Creating a new csv file '%s' with failed APs..." %
+                filename)
     except IOError:
         print("I/O error")
     except Exception as err:
@@ -95,18 +104,25 @@ def dict_list_to_csv(filename, csv_data_list, logger=None):
         else:
             print(str(err))
 
-def get_conn_from_file(filename, account = None, logger=None):
-    """Creates an instance of class`pycentral.ArubaCentralBase` based on the information
+
+def get_conn_from_file(filename, account=None, logger=None):
+    """Creates an instance of class`pycentral.ArubaCentralBase` based on the\
+        information
     provided in the YAML/JSON file. \n
-        * keyword central_info: A dict containing arguments as accepted by class`pycentral.ArubaCentralBase` \n
-        * keyword ssl_verify: A boolean when set to True, the python client validates Aruba Central's SSL certs. \n
+        * keyword central_info: A dict containing arguments as accepted by\
+            class`pycentral.ArubaCentralBase` \n
+        * keyword ssl_verify: A boolean when set to True, the python client\
+            validates Aruba Central's SSL certs. \n
         * keyword token_store: Optional. Defaults to None. \n
 
-    :param filename: Name of a JSON/YAML file containing the keywords required for class:`pycentral.ArubaCentralBase`
+    :param filename: Name of a JSON/YAML file containing the keywords required\
+        for class:`pycentral.ArubaCentralBase`
     :type filename: str
-    :param logger: Provide an instance of class:`logging.logger`, defaults to logger class with name "ARUBA_BASE".
+    :param logger: Provide an instance of class:`logging.logger`, defaults to\
+        logger class with name "ARUBA_BASE".
     :type logger: class:`logging.logger`, optional
-    :return: An instance of class:`pycentral.ArubaCentralBase` to make API calls and manage access tokens.
+    :return: An instance of class:`pycentral.ArubaCentralBase` to make API\
+        calls and manage access tokens.
     :rtype: class:`pycentral.ArubaCentralBase`
     """
     conn = None


### PR DESCRIPTION
Formatted & style linted the following pycentral modules
1. audit_logs
2. base_utils
3. base
4. configuration
5. constants
6. device_inventory
7. firmware_management
8. licensing
9. monitoring
10. rapids
11. refresh_api_token
12. topology file
13. url_utils file
14. user_management
15. visual_rf file
16. workflows_utils