### PR TITLE
v2.0a16

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ pip3 install --upgrade --pre pycentral
 
 ### New Central
 You will need:
-  - **Base URL or Cluster Name**: Base URL is the API Gateway URL for your New Central account based on the geographical cluster of your account on the HPE GreenLake Platform. You can find the base URL or cluster name of your New Central account's API Gateway from the table [here](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#base-urls).
+  - **Base URL or Cluster Name**: Identifies your Central Account's API gateway. Both options function identically. Use whichever is convenient:
+    - **Base URL** —  URL for requests to your Central API Gateway. For instructions on how to locate your Base URL, see [Finding Your Base URL in Central](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#finding-your-base-url).
+    - **Cluster Name** — Name of the cluster where your account is provisioned. A table detailing all cluster names can be found [here](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#api-gateway-base-urls). 
   - **Client ID and Client Secret**: These credentials are required to generate an access token to authenticate API requests. You can obtain them by creating a Personal API Client for your New Central Account. Follow the detailed steps in the [Create Client Credentials documentation](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#create-client-credentials).
 
 ```yaml
@@ -72,36 +74,27 @@ glp:
 ```
 
 Once you have the `token.yaml` file ready, you can run the following Python script:
-
-```python
-import os
+```
 from pycentral import NewCentralBase
 
-# Validate token file exists
 token_file = "token.yaml"
 if not os.path.exists(token_file):
     raise FileNotFoundError(
         f"Token file '{token_file}' not found. Please provide a valid token file."
     )
 
-# Initialize NewCentralBase class with the token credentials for New Central/GLP
-new_central_conn = NewCentralBase(
-    token_info=token_file,
-)
-
-# New Central API Call
-new_central_resp = new_central_conn.command(
-    api_method="GET", api_path="network-monitoring/v1alpha1/aps"
-)
-
-print(new_central_resp)
-print()
-# GLP API Call
-glp_resp = new_central_conn.command(
-    api_method="GET", api_path="devices/v1/devices", app_name="glp"
-)
-
-print(glp_resp)
+with NewCentralBase(token_info=token_file) as conn:
+    # Make the API call to retrieve device inventory
+    resp = conn.command(
+        api_method="GET",
+        api_path="network-monitoring/v1/device-inventory"
+    )
+    
+    # If the response code is 200, print the device inventory response; otherwise, print the error code and message
+    if resp["code"] == 200:
+        print(resp["msg"])
+    else:
+        print(f"Error {resp['code']}: {resp['msg']}")
 ```
 
 Run the script using the following command:
@@ -109,6 +102,7 @@ Run the script using the following command:
 ```bash
 python3 demo.py
 ```
+
 ## Compatibility
 
 - **v2** supports **New Central** and **GLP**.
@@ -118,8 +112,9 @@ python3 demo.py
 ---
 
 ## Documentation
-- [Documentation - Getting Started](https://developer.arubanetworks.com/new-central/docs/getting-started-with-python)
-- [Documentation - Quickstart Guide](https://developer.arubanetworks.com/new-central/docs/pycentral-quickstart-guide)
+- [Getting Started](https://developer.arubanetworks.com/new-central/docs/getting-started-with-python)
+- [Authentication](https://developer.arubanetworks.com/new-central/docs/pycentral-quickstart-guide)
+- [Quickstart Guide](https://developer.arubanetworks.com/new-central/docs/pycentral-quickstart-guide) 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Classic Central functionality is still fully supported by the SDK and has be
 
 ### Documentation
 
-- <a href="https://pycentral.readthedocs.io/en/latest/" target="_blank">Python package documentation</a>
+- <a href="https://pycentral.readthedocs.io/en/v1.4.3/" target="_blank">Python Module documentation</a>
 
 ### **Use-Cases and Workflows**
 - <a href="https://developer.arubanetworks.com/central/docs/python-getting-started" target="_blank">HPE Aruba Networking Developer Hub</a>

--- a/README.md
+++ b/README.md
@@ -78,14 +78,16 @@ Once you have the `token.yaml` file ready, you can run the following Python scri
 import os
 from pycentral import NewCentralBase
 
-# Validate token file existså
+# Validate token file exists
 token_file = "token.yaml"
 if not os.path.exists(token_file):
     raise FileNotFoundError(
         f"Token file '{token_file}' not found. Please provide a valid token file."
     )
 
+# Initialize NewCentralBase class with the token credentials for New Central/GLP
 with NewCentralBase(token_info=token_file) as conn:
+   
     # Make the API call to retrieve device inventory
     resp = conn.command(
         api_method="GET",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ glp:
 ```
 
 Once you have the `token.yaml` file ready, you can run the following Python script:
-```
+```python
+import os
 from pycentral import NewCentralBase
 
 token_file = "token.yaml"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Once you have the `token.yaml` file ready, you can run the following Python scri
 import os
 from pycentral import NewCentralBase
 
+# Validate token file existså
 token_file = "token.yaml"
 if not os.path.exists(token_file):
     raise FileNotFoundError(

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a15/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a16/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a15"
+__version__ = "2.0a16"
 
 from .base import NewCentralBase
 

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -23,7 +23,7 @@ MAX_CONNECTIONS = 7
 
 
 class NewCentralBase:
-    def __init__(self, token_info, logger=None, log_level="DEBUG", enable_scope=False):
+    def __init__(self, token_info, logger=None, log_level="INFO", enable_scope=False):
         """Constructor initializes the NewCentralBase class with token information and logging configuration.
 
         Validates and processes the provided token information, sets up logging,
@@ -34,7 +34,7 @@ class NewCentralBase:
                 applications (new_central, glp). Can also be a string path to a YAML or
                 JSON file with token information.
             logger (logging.Logger, optional): Logger instance. Defaults to None.
-            log_level (str, optional): Logging level. Defaults to "DEBUG".
+            log_level (str, optional): Logging level. Defaults to "INFO".
             enable_scope (bool, optional): Flag to enable scope management. If True, the SDK
                 will automatically fetch data about existing scopes and associated profiles,
                 simplifying scope and configuration management. If False, scope-related API

--- a/pycentral/new_monitoring/devices.py
+++ b/pycentral/new_monitoring/devices.py
@@ -70,7 +70,6 @@ class MonitoringDevices:
         central_conn,
         filter_str=None,
         sort=None,
-        search=None,
         site_assigned=None,
     ):
         """
@@ -80,7 +79,6 @@ class MonitoringDevices:
             central_conn (NewCentralBase): Central connection object.
             filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
             sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            search (str, optional): Search string to filter results.
             site_assigned (str|None, optional): Filter by site-assigned status.
         Returns:
             (list[dict]): Processed list of all devices from inventory.
@@ -93,7 +91,6 @@ class MonitoringDevices:
                 central_conn,
                 filter_str=filter_str,
                 sort=sort,
-                search=search,
                 site_assigned=site_assigned,
                 limit=DEVICE_LIMIT,
                 next=next_int,
@@ -112,7 +109,6 @@ class MonitoringDevices:
         central_conn,
         filter_str=None,
         sort=None,
-        search=None,
         site_assigned=None,
         limit=DEVICE_LIMIT,
         next=1,
@@ -126,7 +122,6 @@ class MonitoringDevices:
             central_conn (NewCentralBase): Central connection object.
             filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
             sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            search (str, optional): Search string to filter results.
             site_assigned (str|None, optional): Filter by site-assigned status. Supported values are "ASSIGNED", "UNASSIGNED"
             limit (int, optional): Number of entries to return (default is 100).
             next (int, optional): Pagination cursor for next page of resources (default is 1).
@@ -140,7 +135,6 @@ class MonitoringDevices:
             "next": next,
             "filter": filter_str,
             "sort": sort,
-            "search": search,
             "site-assigned": site_assigned,
         }
         path = "device-inventory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pytz==2025.2",
     "protobuf==6.33.5",
     "websocket-client==1.9.0",
-    "httpx[http2]==0.28.0",
+    "httpx[http2]==0.28.1",
     "requests==2.32.5"
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
This release removes the deprecated search parameter from monitoring functions and updates the httpx dependency to the latest patch version.

### Improvements

- Removed search parameter from monitoring functions
  - `get_device_inventory()` and `get_all_device_inventory()` no longer accept search as the underlying New Central v1 API no longer supports this filter
- Updated httpx dependency
  - Bumped httpx[http2] from 0.28.0 to 0.28.1 in pyproject.toml
- Changed default log_level from "DEBUG" to "INFO" in NewCentralBase
  - Reduces noise for users who don’t explicitly configure logging
- README updated
  - Quickstart example now uses the context manager pattern (with NewCentralBase(...) as conn) to reflect current best practices
  - Updated Documentation URLs