### PR TITLE
V2.0a17

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -16,26 +16,14 @@ If you're just testing an API, using **Access Token** is fine
 
 ## New Central
 
-**Base URL**  
-   You can find your Central account's base URL from the table here:  
+**Base URL or Cluster Name (Choose one)**
+Identifies your Central Account's API gateway. Both options function identically. Use whichever is convenient:
 
-| Cluster                  | Base URL                               |
-| :----------------------- | :------------------------------------- |
-| EU-1 (eu)                | de1.api.central.arubanetworks.com      |
-| EU-Central2 (eucentral2) | de2.api.central.arubanetworks.com      |
-| EU-Central3 (eucentral3) | de3.api.central.arubanetworks.com      |
-| US-1 (prod)              | us1.api.central.arubanetworks.com      |
-| US-2 (central-prod2)     | us2.api.central.arubanetworks.com      |
-| US-WEST-4 (uswest4)      | us4.api.central.arubanetworks.com      |
-| US-WEST-5 (uswest5)      | us5.api.central.arubanetworks.com      |
-| US-East1 (us-east-1)     | us6.api.central.arubanetworks.com      |
-| Canada-1 (starman)       | ca1.api.central.arubanetworks.com      |
-| APAC-1 (apac)            | in.api.central.arubanetworks.com       |
-| APAC-EAST1 (apaceast)    | jp1.api.central.arubanetworks.com      |
-| APAC-SOUTH1 (apacsouth)  | au1.api.central.arubanetworks.com      |
-| Internal (internal)      | internal.api.central.arubanetworks.com |
+- Base URL
+    Base of the URL for requests to your Central API Gateway. For instructions on how to locate your Base URL, see [Finding Your Base URL in Central](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#finding-your-base-url).
+- Cluster Name
+    Name of the cluster where your account is provisioned. A table detailing all cluster names can be found [here](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#api-gateway-base-urls).
 
-Ensure you use the correct Base URL in your API calls. Using the wrong Base URL will result in failed requests.
 
 **API Credentials** (Choose one):
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,25 +12,7 @@ new_central:
   client_secret: <client-secret>
 ```
 
-Find your base URL:
 
-| Cluster                  | Base URL                               |
-| :----------------------- | :------------------------------------- |
-| EU-1 (eu)                | de1.api.central.arubanetworks.com      |
-| EU-Central2 (eucentral2) | de2.api.central.arubanetworks.com      |
-| EU-Central3 (eucentral3) | de3.api.central.arubanetworks.com      |
-| US-1 (prod)              | us1.api.central.arubanetworks.com      |
-| US-2 (central-prod2)     | us2.api.central.arubanetworks.com      |
-| US-WEST-4 (uswest4)      | us4.api.central.arubanetworks.com      |
-| US-WEST-5 (uswest5)      | us5.api.central.arubanetworks.com      |
-| US-East1 (us-east-1)     | us6.api.central.arubanetworks.com      |
-| Canada-1 (starman)       | ca1.api.central.arubanetworks.com      |
-| APAC-1 (apac)            | in.api.central.arubanetworks.com       |
-| APAC-EAST1 (apaceast)    | jp1.api.central.arubanetworks.com      |
-| APAC-SOUTH1 (apacsouth)  | au1.api.central.arubanetworks.com      |
-| Internal (internal)      | internal.api.central.arubanetworks.com |
-
-In the above `token.yaml` file, only New Central API credentials are provided as the quickstart example script will only be making API calls to New Central. If your script needs to make API calls to GLP, you will need to include your GLP API client credentials or token.
 
 ### Example: Python Script to Get Devices
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,9 @@
 # Quick Start
 With authentication set-up, let's see how to use PyCentral to interact with New Central.
 
+!!! note "Authentication"
+    This guide assumes you already have your API credentials ready. For help obtaining credentials, see the [Authentication Guide](authentication.md).
+
 ## Basic Setup
 Before running a script, create a `token.yaml`. This file provides the authentication credentials required by the SDK to make API calls to New Central.
 You will need to populate it with the required credentials as follows:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a16/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a17/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a16"
+__version__ = "2.0a17"
 
 from .base import NewCentralBase
 

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -6,7 +6,7 @@ from requests_oauthlib import OAuth2Session
 from requests.auth import HTTPBasicAuth
 from oauthlib.oauth2 import BackendApplicationClient
 import json
-import requests
+import time
 from .utils.base_utils import (
     build_url,
     new_parse_input_args,
@@ -20,6 +20,16 @@ import httpx
 
 SUPPORTED_API_METHODS = ("POST", "PATCH", "DELETE", "GET", "PUT")
 MAX_CONNECTIONS = 7
+RETRY_MAX_RETRIES = 3
+RETRY_INITIAL_BACKOFF = 1.0
+RETRY_MAX_BACKOFF = 10.0
+RETRY_BACKOFF_MULTIPLIER = 2.0
+TRANSIENT_TRANSPORT_ERRORS = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.ProxyError,
+)
 
 
 class NewCentralBase:
@@ -96,9 +106,9 @@ class NewCentralBase:
     def create_token(self, app_name):
         """Create a new access token for the specified application.
 
-        Generates a new access token using the client credentials for the specified
-        application, updates the `self.token_info` dictionary with the new token,
-        and optionally saves it to a file.
+        Validates that client credentials exist for the app, then generates a new
+        access token, updates ``self.token_info`` with the new token, and optionally
+        saves it to a file.
 
         Args:
             app_name (str): Name of the application. Supported applications: "new_central", "glp".
@@ -107,9 +117,16 @@ class NewCentralBase:
             (str): Access token.
 
         Raises:
-            LoginError: If there is an error during token creation.
+            LoginError: If client credentials are missing or token creation fails.
         """
-        client_id, client_secret = self._return_client_credentials(app_name)
+        app_token_info = self.token_info[app_name]
+        client_id = app_token_info.get("client_id")
+        client_secret = app_token_info.get("client_secret")
+        if not client_id or not client_secret:
+            msg = f"Please provide client_id and client_secret in {app_name} required to generate an access token"
+            self.logger.error(msg)
+            raise LoginError(msg)
+
         client = BackendApplicationClient(client_id)
 
         oauth = OAuth2Session(client=client)
@@ -152,26 +169,6 @@ class NewCentralBase:
             self.logger.error(msg)
             raise LoginError(msg, status_code)
 
-    def handle_expired_token(self, app_name):
-        """Handle expired access token by creating a new one.
-
-        Args:
-            app_name (str): Name of the application.
-
-        Raises:
-            LoginError: If client credentials are missing.
-        """
-        self.logger.info(
-            f"{app_name} access token has expired. Handling Token Expiry..."
-        )
-        client_id, client_secret = self._return_client_credentials(app_name)
-        if any(credential is None for credential in [client_id, client_secret]):
-            msg = f"Please provide client_id and client_secret in {app_name} required to generate an access token"
-            self.logger.error(msg)
-            raise LoginError(msg)
-        else:
-            self.create_token(app_name)
-
     def command(
         self,
         api_method,
@@ -190,7 +187,7 @@ class NewCentralBase:
 
         The method automatically:
             - Validates the application name and HTTP method
-            - Constructs the full URL from self.base_url and api_path
+            - Constructs the full URL from self.token_info[app_name]["base_url"] and api_path
             - Adds appropriate headers (Content-Type, Accept) if not provided
             - Serializes api_data to JSON when Content-Type is application/json
             - Handles 401 errors by refreshing the access token and retrying if client credentials are available
@@ -256,7 +253,10 @@ class NewCentralBase:
                         )
                         limit_reached = True
                         break
-                    self.handle_expired_token(app_name)
+                    self.logger.info(
+                        f"{app_name} access token has expired. Handling Token Expiry..."
+                    )
+                    self.create_token(app_name)
                     retry += 1
                 else:
                     break
@@ -349,45 +349,68 @@ class NewCentralBase:
 
         Raises:
             ResponseError: If there is an error during the API call.
+
+        Note:
+            Transient transport failures (DNS resolution errors, connection failures,
+            timeouts, and proxy errors) are automatically retried with exponential
+            backoff up to ``RETRY_MAX_RETRIES`` attempts. All other exceptions are
+            raised immediately as ``ResponseError`` without retrying.
         """
         req_headers = dict(headers) if headers else {}
         req_headers["authorization"] = "Bearer " + access_token
 
-        try:
-            # Build keyword args — httpx does not allow content + data + files together
-            kwargs = {
-                "method": method,
-                "url": url,
-                "headers": req_headers,
-            }
-            if params:
-                kwargs["params"] = params
-            if files:
-                # Multipart upload: use files + optional form data (dict only)
-                kwargs["files"] = files
-                if data and isinstance(data, dict):
-                    kwargs["data"] = data
-            elif isinstance(data, str):
-                # Pre-serialized JSON string — pass directly, httpx handles encoding
-                kwargs["content"] = data
-            elif isinstance(data, bytes):
-                # Raw bytes
-                kwargs["content"] = data
-            elif isinstance(data, dict) and data:
-                # Form-encoded dict
+        # Build keyword args — httpx does not allow content + data + files together
+        kwargs = {
+            "method": method,
+            "url": url,
+            "headers": req_headers,
+        }
+        if params:
+            kwargs["params"] = params
+        if files:
+            # Multipart upload: use files + optional form data (dict only)
+            kwargs["files"] = files
+            if data and isinstance(data, dict):
                 kwargs["data"] = data
+        elif isinstance(data, str):
+            # Pre-serialized JSON string — pass directly, httpx handles encoding
+            kwargs["content"] = data
+        elif isinstance(data, bytes):
+            # Raw bytes
+            kwargs["content"] = data
+        elif isinstance(data, dict) and data:
+            # Form-encoded dict
+            kwargs["data"] = data
 
-            http_client = self._http_clients.get(app_name)
-            if http_client is None:
-                http_client = self._create_http_client(app_name)
-                self._http_clients[app_name] = http_client
+        http_client = self._http_clients.get(app_name)
+        if http_client is None:
+            http_client = self._create_http_client(app_name)
+            self._http_clients[app_name] = http_client
 
-            resp = http_client.request(**kwargs)
-            return resp
-        except Exception as err:
-            err_str = f"Failed making request to URL {url} with error {err}"
-            self.logger.error(err_str)
-            raise ResponseError(err_str, err)
+        retry_count = 0
+        while True:
+            try:
+                return http_client.request(**kwargs)
+            except TRANSIENT_TRANSPORT_ERRORS as err:
+                if retry_count >= RETRY_MAX_RETRIES:
+                    err_str = f"Failed making request to URL {url} with error {err}"
+                    self.logger.error(err_str)
+                    raise ResponseError(err_str, err)
+                retry_count += 1
+                delay = min(
+                    RETRY_INITIAL_BACKOFF * (RETRY_BACKOFF_MULTIPLIER ** (retry_count - 1)),
+                    RETRY_MAX_BACKOFF,
+                )
+                self.logger.warning(
+                    "Transient transport failure on %s %s for app %s "
+                    "(retry %s/%s): %s. Retrying in %.1f seconds.",
+                    method, url, app_name, retry_count, RETRY_MAX_RETRIES, err, delay,
+                )
+                time.sleep(delay)
+            except Exception as err:
+                err_str = f"Failed making request to URL {url} with error {err}"
+                self.logger.error(err_str)
+                raise ResponseError(err_str, err)
 
     def _validate_request(self, app_name, method):
         """Validate that provided app has access_token and a valid HTTP method.
@@ -415,24 +438,6 @@ class NewCentralBase:
             )
             self.logger.error(error_string)
             raise ValueError(error_string)
-
-    def _return_client_credentials(self, app_name):
-        """Return client credentials for the specified application.
-
-        Args:
-            app_name (str): Name of the application.
-
-        Returns:
-            (tuple): Client ID and client secret as a tuple (client_id, client_secret).
-        """
-        app_token_info = self.token_info[app_name]
-        if all(
-            client_key in app_token_info
-            for client_key in ("client_id", "client_secret")
-        ):
-            client_id = app_token_info["client_id"]
-            client_secret = app_token_info["client_secret"]
-            return client_id, client_secret
 
     def get_scopes(self):
         """Set up the scopes for the current instance by creating a Scopes object.

--- a/pycentral/scopes/device.py
+++ b/pycentral/scopes/device.py
@@ -86,26 +86,16 @@ class Device(ScopeBase):
         """
 
         # If device_attributes is provided, use it to set attributes
-        self.materialized = from_api
+        self.materialized = False
         self.central_conn = central_conn
         self.type = "device"
         if from_api:
-            # Rename keys if attributes are from API
-            device_attributes = self.__rename_keys(
-                device_attributes, API_ATTRIBUTE_MAPPING
-            )
-            device_attributes["assigned_profiles"] = []
-            for key, value in device_attributes.items():
-                setattr(self, key, value)
-
-            if (
-                self.provisioned_status
-                and device_attributes["device_function"]
-                in SUPPORTED_CONFIG_PERSONAS
-            ):
-                self.config_persona = SUPPORTED_CONFIG_PERSONAS[
-                    device_attributes["device_function"]
-                ]
+            if device_attributes is None:
+                raise ValueError(
+                    "'device_attributes' must be provided when 'from_api=True'."
+                )
+            self._apply_api_attributes(device_attributes)
+            self.materialized = True
         # If only serial is provided, set it and defer fetching other details
         elif serial:
             self.serial = serial
@@ -145,17 +135,11 @@ class Device(ScopeBase):
         )
         self.materialized = len(device_data["items"]) == 1
         if not self.materialized:
-            self.materialized = False
             self.central_conn.logger.error(
                 f"Unable to fetch device {self.get_serial()} from Central"
             )
         else:
-            device_attributes = self.__rename_keys(
-                device_data["items"][0], API_ATTRIBUTE_MAPPING
-            )
-            device_attributes["assigned_profiles"] = []
-            for key, value in device_attributes.items():
-                setattr(self, key, value)
+            self._apply_api_attributes(device_data["items"][0])
             self.central_conn.logger.info(
                 f"Successfully fetched device {self.get_serial()}'s data from Central."
             )
@@ -190,6 +174,27 @@ class Device(ScopeBase):
                 if device.get("isProvisioned") == "Yes"
             ]
         return device_list
+
+    def _apply_api_attributes(self, raw_api_dict):
+        """Renames API response keys and applies them as object attributes.
+
+        Also sets assigned_profiles to an empty list and assigns config_persona
+        if the device is provisioned and its device_function is a supported persona.
+
+        Args:
+            raw_api_dict (dict): Raw dict from the Central API response
+        """
+        device_attributes = self.__rename_keys(raw_api_dict, API_ATTRIBUTE_MAPPING)
+        device_attributes["assigned_profiles"] = []
+        for key, value in device_attributes.items():
+            setattr(self, key, value)
+
+        device_function = device_attributes.get("device_function")
+        if (
+            getattr(self, "provisioned_status", False)
+            and device_function in SUPPORTED_CONFIG_PERSONAS
+        ):
+            self.config_persona = SUPPORTED_CONFIG_PERSONAS[device_function]
 
     def __rename_keys(self, api_dict, api_attribute_mapping):
         """Renames the keys of the attributes from the API response.

--- a/pycentral/scopes/device.py
+++ b/pycentral/scopes/device.py
@@ -140,7 +140,7 @@ class Device(ScopeBase):
 
         device_data = MonitoringDevices.get_device_inventory(
             central_conn=self.central_conn,
-            search=str(self.get_serial()),
+            filter_str=f"serialNumber eq {self.get_serial()}",
             limit=1,
         )
         self.materialized = len(device_data["items"]) == 1

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -2,6 +2,7 @@
 # MIT License
 
 import logging
+import warnings
 import yaml
 import json
 import os
@@ -125,7 +126,17 @@ def _resolve_base_url(app, app_token_info):
                     f"Invalid cluster_name '{cluster_name}' provided. Supported clusters: {', '.join(CLUSTER_BASE_URLS.keys())}"
                 )
         if "base_url" in app_token_info:
-            return valid_url(app_token_info["base_url"])
+            resolved = valid_url(app_token_info["base_url"])
+            known_urls = {u.rstrip("/") for u in CLUSTER_BASE_URLS.values()}
+            if resolved.rstrip("/") not in known_urls:
+                warnings.warn(
+                    f"'{resolved}' is not a recognised Central cluster URL. "
+                    f"Known clusters: {', '.join(CLUSTER_BASE_URLS.keys())}. "
+                    "Proceeding anyway. This is expected for non-production Central clusters",
+                    UserWarning,
+                    stacklevel=4,
+                )
+            return resolved
         raise ValueError(
             "For new_central, either 'cluster_name' or 'base_url' must be provided."
         )

--- a/pycentral/utils/constants.py
+++ b/pycentral/utils/constants.py
@@ -23,18 +23,21 @@ Attributes:
 """
 
 CLUSTER_BASE_URLS = {
-    "EU-1": "https://ge1.api.central.arubanetworks.com",
-    "EU-Central2": "https://ge2.api.central.arubanetworks.com",
-    "EU-Central3": "https://ge3.api.central.arubanetworks.com",
+    "EU-1": "https://de1.api.central.arubanetworks.com",
+    "EU-Central2": "https://de2.api.central.arubanetworks.com",
+    "EU-Central3": "https://de3.api.central.arubanetworks.com",
+    "UK": "https://gb1.api.central.arubanetworks.com",
     "US-1": "https://us1.api.central.arubanetworks.com",
     "US-2": "https://us2.api.central.arubanetworks.com",
     "US-WEST-4": "https://us4.api.central.arubanetworks.com",
     "US-WEST-5": "https://us5.api.central.arubanetworks.com",
     "US-East1": "https://us6.api.central.arubanetworks.com",
-    "Canada-1": "https://cn1.api.central.arubanetworks.com",
-    "APAC-1": "https://in.api.central.arubanetworks.com",
+    "Canada-1": "https://ca1.api.central.arubanetworks.com",
+    "APAC-1": "https://in1.api.central.arubanetworks.com",
     "APAC-EAST1": "https://jp1.api.central.arubanetworks.com",
     "APAC-SOUTH1": "https://au1.api.central.arubanetworks.com",
+    "UAE": "https://ae1.api.central.arubanetworks.com",
+    "China": "https://cn1.api.central.arubanetworks.com.cn",
     "Internal": "https://internal.api.central.arubanetworks.com",
 }
 


### PR DESCRIPTION
This release introduces transient error retry with exponential backoff in the HTTP layer, refactors device attribute initialization, expands the known cluster URL registry, and updates getting-started documentation to clarify authentication prerequisites.

### New Features

- **Retry with Exponential Backoff**
  - `request_url` now automatically retries on transient transport failures (DNS errors, connection failures, timeouts, proxy errors) with exponential backoff up to 3 attempts
  - Added `RETRY_MAX_RETRIES`, `RETRY_INITIAL_BACKOFF`, `RETRY_BACKOFF_MULTIPLIER`, and `TRANSIENT_TRANSPORT_ERRORS` constants to `base.py`
  - All other exceptions are raised immediately as `ResponseError` without retrying
- **Unknown Base URL Warning**
  - `_resolve_base_url` now validates the resolved URL against known cluster URLs
  - Issues a non-fatal `UserWarning` if the URL is not a recognized Central cluster, expected for Central-On Prem & other non-production environments

### Improvements

- Added explicit `self.materialized = False` initialization at the top of `Device.__init__` for clarity
- `from_api` branch in `Device.__init__` now raises `ValueError` if `device_attributes` is `None`, preventing silent failures
- Replaced manual key-rename loop and `setattr` calls in `Device.__init__` with new `_apply_api_attributes()` helper method
- Device inventory fetch in `Device.get()` now uses `filter_str="serialNumber eq {serial}"` instead of the `search=` parameter to match updated API behavior 
- Expanded `CLUSTER_BASE_URLS` in `constants.py` with changes to API Gateway Base URLs
- Removed unused `_return_client_credentials` method from `base.py`
- Updates to `Authentication` & `Quickstart` guide 