### PR TITLE
v2.0a18

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,329 @@
+# 2.0a18
+
+This release introduces unified credential support for GLP and New Central API calls, refines token initialization and refresh behavior, updates authentication guidance, and refreshes package requirements for the 2.0a18 release.
+
+### New Features
+
+- **Unified Credential Support**
+  - Added a new `unified` credential model that allows one GLP credential set to be used for both GLP and New Central API calls
+  - Unified mode uses GLP `client_id`, `client_secret`, and `workspace_id` to generate a single token and reuse it across supported platform requests
+  - Supports GLP-only usage when no Central `base_url` or `cluster_name` is provided
+  - When `unified` credentials are present, standalone `glp` and `new_central` entries are ignored in favor of the unified configuration
+
+### Improvements
+
+- Added support for the global OAuth token issuer flow used by unified credential management
+- Refactored token parsing and route initialization to better support shared-token behavior across GLP and New Central
+- Improved token creation and refresh error handling with clearer validation and more actionable failures for invalid credentials or incomplete configuration
+- Updated authentication documentation with unified credential guidance, required fields, and example configurations
+- Bumped package version references to `2.0a18`
+- Updated package requirements in `pyproject.toml`, including Python version support and the pinned `requests` dependency
+
+Full Changelog: [v2.0a17...v2.0a18](https://github.com/aruba/pycentral/compare/v2.0a17...v2.0a18)
+
+# 2.0a17
+
+This release introduces transient error retry with exponential backoff in the HTTP layer, refactors device attribute initialization, expands the known cluster URL registry, and updates getting-started documentation to clarify authentication prerequisites.
+
+### New Features
+
+- **Retry with Exponential Backoff**
+  - `request_url` now automatically retries on transient transport failures (DNS errors, connection failures, timeouts, proxy errors) with exponential backoff up to 3 attempts
+  - Added `RETRY_MAX_RETRIES`, `RETRY_INITIAL_BACKOFF`, `RETRY_BACKOFF_MULTIPLIER`, and `TRANSIENT_TRANSPORT_ERRORS` constants to `base.py`
+  - All other exceptions are raised immediately as `ResponseError` without retrying
+- **Unknown Base URL Warning**
+  - `_resolve_base_url` now validates the resolved URL against known cluster URLs
+  - Issues a non-fatal `UserWarning` if the URL is not a recognized Central cluster, expected for Central-On Prem & other non-production environments
+
+### Improvements
+
+- Added explicit `self.materialized = False` initialization at the top of `Device.__init__` for clarity
+- `from_api` branch in `Device.__init__` now raises `ValueError` if `device_attributes` is `None`, preventing silent failures
+- Replaced manual key-rename loop and `setattr` calls in `Device.__init__` with new `_apply_api_attributes()` helper method
+- Device inventory fetch in `Device.get()` now uses `filter_str="serialNumber eq {serial}"` instead of the `search=` parameter to match updated API behavior
+- Expanded `CLUSTER_BASE_URLS` in `constants.py` with changes to API Gateway Base URLs
+- Removed unused `_return_client_credentials` method from `base.py`
+- Updates to `Authentication` & `Quickstart` guide
+
+Full Changelog: [v2.0a16...v2.0a17](https://github.com/aruba/pycentral/compare/v2.0a16...v2.0a17)
+
+# 2.0a16
+
+This release removes the deprecated search parameter from monitoring functions and updates the httpx dependency to the latest patch version.
+
+### Improvements
+
+- Removed search parameter from monitoring functions
+  - `get_device_inventory()` and `get_all_device_inventory()` no longer accept `search` parameter as the underlying Central API no longer supports this filter
+- Updated httpx dependency
+  - Bumped httpx[http2] from 0.28.0 to 0.28.1 in pyproject.toml
+- Changed default `log_level` from `"DEBUG"` to `"INFO"` in `NewCentralBase`
+  - Reduces noise for users who do not explicitly configure logging
+- README updated
+  - Quickstart example now uses the context manager pattern (`with NewCentralBase(...) as conn`) to reflect current best practices
+  - Updated documentation URLs
+
+Full Changelog: [v2.0a15...v2.0a16](https://github.com/aruba/pycentral/compare/v2.0a15...v2.0a16)
+
+# 2.0a15
+
+This release migrates core monitoring modules to stable v1 APIs, replaces the HTTP client with HTTPX for persistent connection reuse, and introduces several bug fixes, stability improvements, and developer experience enhancements across the SDK.
+
+### New Features
+
+- HTTPX Migration
+  - Replaced `requests.Session` with `httpx` for persistent connection reuse across API calls in `base.py`
+  - Eliminates per-call connection overhead, significantly improving SDK performance
+  - Supporting helper functions added to `base.py` to modularize command function internals
+- v1 API Migration
+  - Migrated modules of `MonitoringAPs`, `Clients`, `MonitoringDevices`, and `MonitoringSites` from Alpha/Beta APIs to stable v1 endpoints
+  - Higher rate limits and expanded capabilities available for all migrated modules due to v1 API support
+- Context Manager Support
+  - `with` syntax now supported for SDK client instantiation
+- Streaming: Ping-Pong Support
+  - Added ping-pong capability to the streaming module to sustain longer-lived WebSocket connections
+- Project Modernization
+  - Migrated project initialization from `setup.py` to `pyproject.toml`
+
+### Improvements
+
+- Fixed duplicate `requests.Session` instantiation in Classic Central's `base.py`; session is now initialized once at startup and reused across API calls (Closes #65)
+- Resolved bugs in log statements and return values within util modules - `scope_utils.py` & `monitoring_utils.py`
+- Abstracted valid personas into a dedicated structure for easier maintenance in `constants.py`
+- Added extra validation checks across scope-related helper functions in `scope_base.py` & `scopemaps.py`
+- Updated URL utils to default to v1 endpoints unless explicitly overridden
+- Documentation updates for all above changes
+
+Full Changelog: [v2.0a14...v2.0a15](https://github.com/aruba/pycentral/compare/v2.0a14...v2.0a15)
+
+# 2.0a14
+
+This release improves profile retrieval reliability, refines the show commands interface to support increased input handling, and extends client management functionality with new helper utilities and dependency updates.
+
+### Improvements
+
+- Updated `get_profile` docstring and added handling for invalid URL responses to improve robustness during profile lookups
+- Updated show command methods across Troubleshooting & Device classes to reflect API changes. Related functions now accept either a string or a list of strings representing the set of show commands to be run on the devices
+- Updated dependencies: `requests==2.32.5`, `PyYAML==6.0.3`, `protobuf==6.33.5` to ensure compatibility and stability
+- Added `get_client_details` method to fetch client-specific details
+- Added `_validate_mac_address` helper method to support input validation for MAC address fields
+
+Full Changelog: [v2.0a13...v2.0a14](https://github.com/aruba/pycentral/compare/v2.0a13...v2.0a14)
+
+# 2.0a13
+
+This release expands monitoring and troubleshooting capabilities and introduces SDK-level support for Streaming APIs, enabling developers to consume supported WebSocket-based event streams using a native client and decoders.
+
+### New Features
+
+- Monitoring Enhancements
+  - Added new methods under `MonitoringAPIs`:
+    - `get_wlans`
+    - `get_ap_wlans`
+  - These methods allow users to retrieve WLAN data associated with a specific AP or across all APs, aligning with the underlying monitoring API implementations
+- Troubleshooting Events Support
+  - Added support for troubleshooting events via the new `list_events` method. This method enables retrieval of network events using query-based filtering
+  - Implemented method across `Troubleshooting` and `Device` classes to provide consistent access patterns
+- Streaming APIs Support
+  - Added SDK support for consuming Streaming APIs with a built-in streaming client that handles connection management and event decoding
+  - Introduced streaming topic decoders with support for the following event types:
+    - Audit Trail
+    - Location
+    - Location Analytics
+    - Geofence
+  - Added accompanying documentation to guide users on streaming setup, topic usage, and event decoding
+
+### Improvements
+
+- Fixed minor bugs and applied cleanup across methods in `scope_utils.py`
+- Improved stability and consistency of scope-related helper functions, including `get_all_scope_elements`
+
+Full Changelog: [v2.0a12...v2.0a13](https://github.com/aruba/pycentral/compare/v2.0a12...v2.0a13)
+
+# 2.0a12
+
+This release focuses on expanding troubleshooting capabilities and improving how the SDK documents and exposes its public methods.
+
+### New Features
+
+- Added new troubleshooting modules that expose additional troubleshooting methods - `list_show_commands`, `list_active_tasks`, `run_show_command`, `initiate_show_command`, `get_show_command_result`
+- Introduced troubleshooting helpers in the `Devices` class to support new methods mentioned above
+
+### Updates
+
+- Migrated docstrings from Sphinx style to Google style across core modules (e.g. `Devices`, `Monitoring`, `Troubleshooting`, `Sites`, `Profiles`, and related utilities)
+  - Standardized parameter/return/exception sections for better readability and IDE support
+  - Added missing docstrings for existing public methods to keep behavior and usage clearly documented
+- Removed legacy Sphinx documentation files that are no longer used by the current docs pipeline
+- Removed unused custom exceptions such as `UnsupportedCapabilityError` & `GenericOperationError`
+- Replaced direct `exit` calls with raised exceptions so error handling is consistent and easier for applications to manage
+
+### Improvements
+
+- Removed duplicate endpoint implementations in the `Devices` class where equivalent functionality already exists in the Monitoring modules; `Devices` now reuses the Monitoring implementations instead of maintaining separate copies
+- Improved overall error-handling to align with the new exception model
+
+Full Changelog: [v2.0a11...v2.0a12](https://github.com/aruba/pycentral/compare/v2.0a11...v2.0a12)
+
+# 2.0a11
+
+1. Updated logic of device function to persona mapping to match API behaviour
+2. Updates to documentation for certain functions
+3. Resolved minor issues of GLP Subscriptions module
+
+Full Changelog: [v2.0a10...v2.0a11](https://github.com/aruba/pycentral/compare/v2.0a10...v2.0a11)
+
+# 2.0a10
+
+This update introduces new Monitoring modules that simplify how users access site/device/client metrics, while also removing deprecated profiles and improving URL generation for a cleaner and more efficient SDK usage experience.
+
+### New Features
+
+This release introduces new Monitoring modules that expose Monitoring API capabilities across Sites, Devices, Access Points, Gateways, and Clients.
+These modules provide direct methods for common monitoring tasks, eliminating the need to manually call endpoints, handle pagination, or build aggregation logic.
+
+Monitoring Modules Added:
+- Sites: `get_all_sites`, `get_sites`, `get_site_device_health`, `list_site_information`
+- Devices: `get_all_devices`, `get_devices`, `get_device_inventory`, `delete_device`
+- Access Points: `get_all_aps`, `get_aps`, `get_latest_ap_stats`, `get_ap_cpu_utilization`, `get_ap_memory_utilization`, `get_ap_poe_utilization`
+- Gateways: `get_all_gateways`, `get_gateways`, `get_cluster_leader_details`, `get_gateway_details`, `get_gateway_interfaces`, `get_gateway_lan_tunnels`, `get_stats`, `get_latest_gateway_stats`, `get_gateway_cpu_utilization`, `get_gateway_memory_utilization`, `get_gateway_wan_availability`, `get_tunnel_health_summary`
+- Clients: `get_all_site_clients`, `get_wireless_clients`, `get_wired_clients`, `get_clients_associated_device`, `get_connected_clients`, `get_disconnected_clients`, `get_site_clients`, `get_client_trends`, `get_top_n_site_clients`
+
+### Updates
+
+- Removed deprecated modules and related dead code - `Policy`, `Role`, `SystemInfo`, `Vlan`, `Wlan`
+  - Please use `Profiles` class instead of the above modules
+- Improved Profiles documentation and overall code quality of module methods
+
+### Improvements
+
+- Introduced new `generate_url` function to simplify URL generation and parameter handling
+- Split category mappings and API endpoints into dedicated files for cleaner import flows
+- Replaced all legacy `fetch_url` and `generate_url_with_params` usage
+- Removed unused `NewCentralURLs` imports
+
+Full Changelog: [v2.0a9...v2.0a10](https://github.com/aruba/pycentral/compare/v2.0a9...v2.0a10)
+
+# 2.0a9
+
+This update primarily extends the Troubleshooting module with new methods, and introduces supporting documentation. It also reorganizes the Troubleshooting class for improved efficiency and readability, while ensuring the Device class supports all new troubleshooting methods.
+
+### New Features
+
+- Troubleshooting Class
+  - Added support for new methods:
+    - AAA test implementation for Access Points (APs)
+    - NSLOOKUP test for APs
+    - User disconnect functions for APs
+    - Client disconnect functions for Gateways
+  - Added a `troubleshooting.md` file that documents all supported troubleshooting test in the SDK, including corresponding methods along with supported device types
+- Device Class
+  - Added support for all newly introduced troubleshooting methods
+- Scopes Module
+  - Added `find_device_group` method
+
+### Updates
+
+- Troubleshooting Class
+  - Replaced `ping_test` method with `ping_aps_test`, `ping_cx_test`, `ping_aoss_test`, `ping_gateways_test` to align with device-type-specific troubleshooting attributes
+  - Replaced `traceroute_test` method with `traceroute_aps_test`, `traceroute_cx_test`, `traceroute_aoss_test`, `traceroute_gateways_test` to align with device-type-specific troubleshooting attributes
+
+### Improvements
+
+- Troubleshooting Class
+  - Reorganized Troubleshooting class for efficiency, readability, and easier future maintenance
+  - Removed redundant checks on troubleshooting test attributes
+
+Full Changelog: [v2.0a8...v2.0a9](https://github.com/aruba/pycentral/compare/v2.0a8...v2.0a9)
+
+# 2.0a8
+
+This update adds a dedicated Troubleshooting class with new diagnostic methods across multiple device types, enhances the Device class, and includes key dependency updates and cleanup.
+
+### New Features
+
+- `Troubleshooting` Class - Added support for Access Points, AOS-CX, AOS-S, and Gateways
+  - New troubleshooting methods - Ping, Traceroute, Reboot, Locate, HTTP/HTTPS Tests, Port Bounce, PoE Bounce, ARP Table, Speedtest, AAA Test, Cable Test, and Iperf Test
+- `Device` Class - Now supports all troubleshooting methods
+
+### Updates
+
+- Updated dependencies:
+  - `requests`: 2.32.3 -> 2.32.4
+  - `pytz`: 2024.1 -> 2025.2
+- Removed unused dependencies: `urllib3`, `certifi`, `termcolor`
+
+### Improvements
+
+- Removed minimum site collection requirement for fetching global ID and profile correlation in scopes
+- Enhanced error logging for scope initialization without a site
+
+Full Changelog: [v2.0a7...v2.0a8](https://github.com/aruba/pycentral/compare/v2.0a7...v2.0a8)
+
+# 2.0a7
+
+This update introduces support for Device_Group in Scopes, improves persona assignment workflows, and fixes key bugs related to scope correlation and device identification.
+
+### New Features
+
+- Device Group Class - Introduced `Device_Group` class for use in Scopes & integrated into `ScopeBase` to ensure consistency with other scope types
+- Scope Class Enhancements
+  - Added `type` attribute to all scope-related classes: `Scopes`, `Site`, `Site_Collection`, `Device`, `Device_Group`
+  - Improved `get_all_devices` method in the `Device` class:
+    - Method uses `isProvisioned` to filter devices configured via the new Central
+- Profile Persona
+  - Added support for configuration persona for devices based on their function. This simplifies profile management for devices
+  - `assign_profile`, `unassign_profile` methods now accept `profile_persona` as an optional parameter for devices
+  - Added `SUPPORTED_CONFIG_PERSONAS` to `constants.py` for better maintainability
+
+### Bug Fixes
+
+- Fixed `_correlate_scopes` to ensure accurate correlation logic in `Scopes` class
+- Improved logging in `_find_scope_element` method to clarify unknown scope errors in `Scopes` class
+- Updated `rename_keys` in `Device` class to update device IDs as `int` instead of `string` for consistency with other IDs
+
+Full Changelog: [v2.0a6...v2.0a7](https://github.com/aruba/pycentral/compare/v2.0a6...v2.0a7)
+
+# 2.0a6
+
+- Added Scope modules -
+  - ScopeBase
+  - Scope (Managing scope & Global)
+  - Site Collection - CRUD Operations
+  - Site - CRUD Operations
+  - Device
+  - Other scope management modules
+- Added Config Profile modules -
+  - Profile base
+  - Policy
+  - Role
+  - System Info
+  - VLAN
+  - WLAN
+- Enhancements to base module to support `enable_scope` attribute
+  - This will fetch scope hierarchy related data to simplify automation scripting with SDK
+
+Full Changelog: [v2.0a5...v2.0a6](https://github.com/aruba/pycentral/compare/v2.0a5...v2.0a6)
+
+# 2.0a5
+
+- Fixed bugs with `get_all_devices` and `get_all_subscriptions` in `Device` & `Subscriptions` modules
+- Documentation updates for `Devices` & `Subscriptions` module
+- Added `ServiceManager` GLP module
+
+Full Changelog: [v2.0a3...v2.0a5](https://github.com/aruba/pycentral/compare/v2.0a3...v2.0a5)
+
+# 2.0a3
+
+- Token management support for New Central & GreenLake (GLP) API calls
+- Backwards compatibility with Classic Central API calls & PyCentral-v1
+- Added ability to make API calls to New Central & GLP via base module
+- Introduced GLP modules for managing Devices, Subscriptions, & Users
+- Enabled token reuse by storing generated tokens in provided token file (YAML/JSON)
+- Added support for optionally providing `cluster_name` instead of `base_url` for New Central token information
+
+Full Changelog: [v1.4.1...v2.0a3](https://github.com/aruba/pycentral/compare/v1.4.1...v2.0a3)
+
 # 1.4.1
 
 ## Notable Changes

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -58,6 +58,55 @@ Classic Central suppports authentication methods for access tokens or generating
 - Access Token  
     Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/central/docs/api-gateway-creating-application-token). **(Tokens expire in 2 hours)**
 
+## Unified Credentials
+
+PyCentral also supports a **unified credential** model. Instead of providing separate `glp` and `new_central` credential blocks, you provide one `unified` block using your GLP client credentials. The SDK generates one token through GLP auth (using `workspace_id`) and reuses that same token for both GLP and New Central API calls.
+
+### How It Works
+
+- You provide GLP `client_id`, `client_secret`, and `workspace_id` in a single `unified` block.
+- The SDK creates one access token via GLP and uses it for both GLP and New Central calls.
+- No separate `glp` or `new_central` credential blocks are needed. If `unified` is present, standalone `glp` and `new_central` entries are ignored.
+
+### Required Fields
+
+| Field | Required | Description |
+| :--- | :--- | :--- |
+| `client_id` | Yes | GLP client ID |
+| `client_secret` | Yes | GLP client secret |
+| `workspace_id` | Yes | GLP workspace ID |
+| `base_url` or `cluster_name` | Only for New Central calls | Identifies the Central API gateway. Omit if you only need GLP APIs |
+| `access_token` | No | Pre-existing token; if omitted the SDK generates one automatically |
+
+### Configuration Examples
+
+**Unified — GLP + New Central**
+
+```python
+token_info = {
+    "unified": {
+        "client_id": "<glp-client-id>",
+        "client_secret": "<glp-client-secret>",
+        "workspace_id": "<workspace-id>",
+        "cluster_name": "Internal"  # or "base_url": "https://apigw-<cluster>.central.arubanetworks.com"
+    }
+}
+```
+
+**Unified — GLP Only**
+
+```python
+token_info = {
+    "unified": {
+        "client_id": "<glp-client-id>",
+        "client_secret": "<glp-client-secret>",
+        "workspace_id": "<workspace-id>"
+    }
+}
+```
+
+This enables GLP APIs only. Add `base_url` or `cluster_name` to also enable New Central APIs.
+
 ## Next Steps
 
 - [Quick Start](quickstart.md) - Start using PyCentral

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a17/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a18/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a17"
+__version__ = "2.0a18"
 
 from .base import NewCentralBase
 

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -14,7 +14,6 @@ from .utils.base_utils import (
     save_access_token,
 )
 from .scopes import Scopes
-from .utils import AUTHENTICATION
 from .exceptions import LoginError, ResponseError
 import httpx
 
@@ -34,7 +33,8 @@ TRANSIENT_TRANSPORT_ERRORS = (
 
 class NewCentralBase:
     def __init__(self, token_info, logger=None, log_level="INFO", enable_scope=False):
-        """Constructor initializes the NewCentralBase class with token information and logging configuration.
+        """
+        Constructor initializes the NewCentralBase class with token information and logging configuration.
 
         Validates and processes the provided token information, sets up logging,
         and optionally initializes scope-related functionality.
@@ -55,22 +55,17 @@ class NewCentralBase:
         if isinstance(token_info, str):
             self.token_file_path = token_info
         self.logger = self.set_logger(log_level, logger)
+        self._app_routes = self._build_app_routes()
         self.scopes = None
         self._http_clients = {}
-        for app_name in self.token_info:
-            self._http_clients[app_name] = self._create_http_client(app_name)
-        for app in self.token_info:
-            app_token_info = self.token_info[app]
-            if (
-                "access_token" not in app_token_info
-                or app_token_info["access_token"] is None
-            ):
-                self.create_token(app)
+        self._initialize_http_clients()
+        self._initialize_tokens()
         if enable_scope:
             self.scopes = Scopes(central_conn=self)
 
     def set_logger(self, log_level, logger=None):
-        """Set up the logger.
+        """
+        Set up the logger.
 
         Args:
             log_level (str): Logging level.
@@ -84,18 +79,84 @@ class NewCentralBase:
         else:
             return console_logger("NEW CENTRAL BASE", log_level)
 
+    def _build_app_routes(self):
+        """
+        Build a per-app routing table from token_info, computed once at init.
+
+        Maps each caller-facing app name ('glp', 'new_central') to its
+        base_url and the token_info key holding the access token.
+
+        Returns:
+            (dict): Mapping of app_name to {"base_url": str, "token_key": str}.
+
+        Note:
+            Internal SDK function
+        """
+        routes = {}
+        if "unified" in self.token_info:
+            unified = self.token_info["unified"]
+            routes["glp"] = {
+                "base_url": unified["glp_base_url"],
+                "token_key": "unified",
+            }
+            if unified.get("base_url"):
+                routes["new_central"] = {
+                    "base_url": unified["base_url"],
+                    "token_key": "unified",
+                }
+        else:
+            for app_name, app_info in self.token_info.items():
+                routes[app_name] = {
+                    "base_url": app_info["base_url"],
+                    "token_key": app_name,
+                }
+        return routes
+
+    def _initialize_http_clients(self):
+        """Create HTTP clients for every app in the routing table."""
+        for app_name in self._app_routes:
+            self._http_clients[app_name] = self._create_http_client(app_name)
+        if "unified" in self.token_info and "new_central" not in self._app_routes:
+            self.logger.info(
+                "Unified mode: no 'base_url' or 'cluster_name' was provided for "
+                "Central. Only GLP API calls are supported. Add 'base_url' or "
+                "'cluster_name' under 'unified' credentials to also enable Central calls."
+            )
+
+    def _initialize_tokens(self):
+        """Fetch an access token for any app that does not already have one."""
+        for app in list(self.token_info):
+            app_token_info = self.token_info[app]
+            if (
+                "access_token" not in app_token_info
+                or app_token_info["access_token"] is None
+            ):
+                self.create_token(app)
+
     def _create_http_client(self, app_name):
-        """Create an HTTP client for a specific app.
+        """
+        Create an HTTP client for a specific app.
 
         Uses tuned connection limits for New Central and default connection
         limits for all other apps (including GLP).
+
+        Args:
+            app_name (str): Name of the application (e.g., "new_central", "glp").
+
+        Returns:
+            (httpx.Client): Configured HTTP client instance.
+
+        Note:
+            Internal SDK function
         """
         client_kwargs = {
             "http2": True,
             "timeout": httpx.Timeout(30.0, connect=10.0),
             "verify": True,
         }
-        if app_name == "new_central":
+        # Apply tuned connection limits for Central requests
+        # (both standalone new_central and the unified platform client for Central)
+        if app_name in ("new_central",):
             client_kwargs["limits"] = httpx.Limits(
                 max_connections=MAX_CONNECTIONS,
                 max_keepalive_connections=5,
@@ -104,11 +165,12 @@ class NewCentralBase:
         return httpx.Client(**client_kwargs)
 
     def create_token(self, app_name):
-        """Create a new access token for the specified application.
+        """
+        Create a new access token for the specified application.
 
-        Validates that client credentials exist for the app, then generates a new
-        access token, updates ``self.token_info`` with the new token, and optionally
-        saves it to a file.
+        Generates a new access token using the client credentials for the specified
+        application, updates the self.token_info dictionary with the new token,
+        and optionally saves it to a file.
 
         Args:
             app_name (str): Name of the application. Supported applications: "new_central", "glp".
@@ -117,25 +179,25 @@ class NewCentralBase:
             (str): Access token.
 
         Raises:
-            LoginError: If client credentials are missing or token creation fails.
+            LoginError: If there is an error during token creation.
         """
-        app_token_info = self.token_info[app_name]
-        client_id = app_token_info.get("client_id")
-        client_secret = app_token_info.get("client_secret")
-        if not client_id or not client_secret:
-            msg = f"Please provide client_id and client_secret in {app_name} required to generate an access token"
-            self.logger.error(msg)
-            raise LoginError(msg)
-
+        client_id, client_secret = self._return_client_credentials(app_name)
         client = BackendApplicationClient(client_id)
 
         oauth = OAuth2Session(client=client)
         auth = HTTPBasicAuth(client_id, client_secret)
 
+        token_url = self.token_info[app_name].get("_token_url")
+        if not token_url:
+            raise ValueError(
+                f"Cannot determine token URL for '{app_name}'. "
+                "Ensure valid credentials (including workspace_id for unified mode) are provided."
+            )
+
         try:
             self.logger.info(f"Attempting to create new token from {app_name}")
-            token = oauth.fetch_token(token_url=AUTHENTICATION["OAUTH"], auth=auth)
-
+            token = oauth.fetch_token(token_url=token_url, auth=auth)
+            self.logger.debug(f"Token response for {app_name}: {token}")
             if "access_token" in token:
                 self.logger.info(
                     f"{app_name} Login Successful.. Obtained Access Token!"
@@ -179,7 +241,8 @@ class NewCentralBase:
         headers=None,
         files=None,
     ):
-        """Execute an API command to HPE Aruba Networking Central or GreenLake Platform.
+        """
+        Execute an API command to HPE Aruba Networking Central or GreenLake Platform.
 
         This is the primary method for making API calls from the SDK. It handles
         authentication, token refresh on expiry, request formatting, and response
@@ -187,7 +250,7 @@ class NewCentralBase:
 
         The method automatically:
             - Validates the application name and HTTP method
-            - Constructs the full URL from self.token_info[app_name]["base_url"] and api_path
+            - Constructs the full URL from self.base_url and api_path
             - Adds appropriate headers (Content-Type, Accept) if not provided
             - Serializes api_data to JSON when Content-Type is application/json
             - Handles 401 errors by refreshing the access token and retrying if client credentials are available
@@ -229,9 +292,11 @@ class NewCentralBase:
         req_headers = self._build_request_headers(headers, files)
         req_data = self._serialize_request_data(api_data, req_headers)
 
-        url = build_url(self.token_info[app_name]["base_url"], api_path)
+        route = self._app_routes[app_name]
+        url = build_url(route["base_url"], api_path)
 
         retry = 0
+        resp = None
         limit_reached = False
         try:
             while not limit_reached:
@@ -242,7 +307,7 @@ class NewCentralBase:
                     headers=req_headers,
                     params=api_params,
                     files=files,
-                    access_token=self.token_info[app_name]["access_token"],
+                    access_token=self.token_info[route["token_key"]]["access_token"],
                     app_name=app_name,
                 )
                 if resp.status_code == 401:
@@ -256,10 +321,16 @@ class NewCentralBase:
                     self.logger.info(
                         f"{app_name} access token has expired. Handling Token Expiry..."
                     )
-                    self.create_token(app_name)
+                    self.create_token(route["token_key"])
                     retry += 1
                 else:
                     break
+
+            if resp is None:
+                raise ResponseError(
+                    f"{api_method} FAILURE ",
+                    RuntimeError(f"No response returned for {api_method} {url}"),
+                )
 
             result = {
                 "code": resp.status_code,
@@ -280,7 +351,18 @@ class NewCentralBase:
             raise ResponseError(err_str, err)
 
     def _prepare_query_params(self, api_params):
-        """Return query params with None-valued entries removed."""
+        """
+        Return query params with None-valued entries removed.
+
+        Args:
+            api_params (dict or None): Query parameters to filter.
+
+        Returns:
+            (dict): Query parameters with None values removed.
+
+        Note:
+            Internal SDK function
+        """
         if api_params is None:
             return {}
         if isinstance(api_params, dict):
@@ -290,7 +372,19 @@ class NewCentralBase:
         return api_params
 
     def _build_request_headers(self, headers, files):
-        """Build request headers without mutating caller-provided headers."""
+        """
+        Build request headers without mutating caller-provided headers.
+
+        Args:
+            headers (dict or None): Custom HTTP headers provided by the caller.
+            files (dict): Files dictionary for multipart upload requests.
+
+        Returns:
+            (dict): Request headers to use for the API call.
+
+        Note:
+            Internal SDK function
+        """
         if headers:
             return dict(headers)
         if not files:
@@ -301,7 +395,19 @@ class NewCentralBase:
         return {}
 
     def _serialize_request_data(self, api_data, req_headers):
-        """Serialize payload for JSON requests; otherwise pass through as-is."""
+        """
+        Serialize payload for JSON requests; otherwise pass through as-is.
+
+        Args:
+            api_data (dict or str or bytes): Request payload data.
+            req_headers (dict): Request headers (used to detect Content-Type).
+
+        Returns:
+            (str or dict or bytes): Serialized request data.
+
+        Note:
+            Internal SDK function
+        """
         content_type = next(
             (
                 header_value
@@ -413,7 +519,8 @@ class NewCentralBase:
                 raise ResponseError(err_str, err)
 
     def _validate_request(self, app_name, method):
-        """Validate that provided app has access_token and a valid HTTP method.
+        """
+        Validate that the provided app name is configured and the HTTP method is supported.
 
         Args:
             app_name (str): Name of the application.
@@ -423,9 +530,9 @@ class NewCentralBase:
             ValueError: If app_name is not in token_info or access_token is missing.
             ValueError: If the method is not supported.
         """
-        if app_name not in self.token_info:
+        if app_name not in self._app_routes:
             error_string = (
-                f"Missing access_token for {app_name}. Please provide access token "
+                f"Missing configuration for '{app_name}'. Please provide access token "
                 f"or client credentials to generate an access token for app - {app_name}"
             )
             self.logger.error(error_string)
@@ -439,11 +546,35 @@ class NewCentralBase:
             self.logger.error(error_string)
             raise ValueError(error_string)
 
-    def get_scopes(self):
-        """Set up the scopes for the current instance by creating a Scopes object.
+    def _return_client_credentials(self, app_name):
+        """
+        Return client credentials for the specified application.
 
-        Initializes the `scopes` attribute using the `Scopes` class, passing the
-        current instance as the `central_conn` parameter. If the `scopes` attribute
+        Args:
+            app_name (str): Name of the application.
+
+        Returns:
+            (tuple): Client ID and client secret as a tuple (client_id, client_secret).
+        """
+        app_token_info = self.token_info[app_name]
+        if all(
+            client_key in app_token_info
+            for client_key in ("client_id", "client_secret")
+        ) and app_token_info["client_id"] and app_token_info["client_secret"]:
+            client_id = app_token_info["client_id"]
+            client_secret = app_token_info["client_secret"]
+            return client_id, client_secret
+        raise ValueError(
+            f"Missing 'client_id' or 'client_secret' for app '{app_name}'. "
+            "Provide valid client credentials to create an access token."
+        )
+
+    def get_scopes(self):
+        """
+        Set up the scopes for the current instance by creating a Scopes object.
+
+        Initializes the scopes attribute using the Scopes class, passing the
+        current instance as the central_conn parameter. If the scopes attribute
         is already initialized, it simply returns the existing object.
 
         Returns:
@@ -468,7 +599,7 @@ class NewCentralBase:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.logger.debug("Closing connections to Central/GLP and cleaning up...")
+        self.logger.info("Closing HTTP client and releasing resources...")
         self.close()
 
     # Garbage collection fallback — close if user forgets

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -7,7 +7,7 @@ import yaml
 import json
 import os
 from urllib.parse import urlencode, urlparse, urlunparse
-from .constants import CLUSTER_BASE_URLS, GLP_URLS
+from .constants import AUTHENTICATION, CLUSTER_BASE_URLS, GLP_URLS
 from .common_utils import parse_input_file
 
 try:
@@ -16,27 +16,35 @@ try:
     COLOR = True
 except (ImportError, ModuleNotFoundError):
     COLOR = False
-C_LOG_LEVEL = {
-    "CRITICAL": 50,
-    "ERROR": 40,
-    "WARNING": 30,
-    "INFO": 20,
-    "DEBUG": 10,
-    "NOTSET": 0,
-}
-
-SUPPORTED_APPS = ["new_central", "glp"]
+SUPPORTED_APPS = ["new_central", "glp", "unified"]
 NEW_CENTRAL_C_DEFAULT_ARGS = {
     "base_url": None,
     "client_id": None,
     "client_secret": None,
     "access_token": None,
 }
-URL_BASE_ERR_MESSAGE = "Please provide the base_url of API Gateway where Central account is provisioned!"
+UNIFIED_DEFAULT_ARGS = {
+    "client_id": None,
+    "client_secret": None,
+    "workspace_id": None,
+    "glp_base_url": None,
+    "base_url": None,
+    "access_token": None,
+}
 
+APP_TOKEN_CREATION_REQUIRED_KEYS = {
+    "new_central": {"client_id", "client_secret"},
+    "glp": {"client_id", "client_secret"},
+    "unified": {"client_id", "client_secret", "workspace_id"},
+}
+
+URL_BASE_ERR_MESSAGE = (
+    "Please provide the base_url of API Gateway where Central account is provisioned!"
+)
 
 def new_parse_input_args(token_info):
-    """Parse and validate the input token information.
+    """
+    Parse and validate the input token information.
 
     Args:
         token_info (dict or str): Dictionary containing token information or a file path
@@ -47,37 +55,75 @@ def new_parse_input_args(token_info):
 
     Raises:
         ValueError: If the token_info is invalid.
+
+    Note:
+        When "unified" credentials are present, any "glp" or "new_central" entries
+        in the same dict are ignored. Unified mode requires client credentials
+        (`client_id`, `client_secret`, and `workspace_id`). An optional
+        `access_token` can be provided to skip initial token creation; the
+        client credentials are still required for token refresh when the
+        access token expires. Pass `base_url` or `cluster_name` under
+        `unified` to also enable Central API calls.
     """
     token_info = load_token_info(token_info)
 
-    apps_token_info = {}
-
-    for app, app_token_info in token_info.items():
-        if app not in SUPPORTED_APPS:
-            raise ValueError(
-                f"Unknown app name '{app}' provided. Supported apps: {', '.join(SUPPORTED_APPS)}"
-            )
-
-        # Resolve base_url using cluster_name or validate provided base_url
-        app_token_info["base_url"] = _resolve_base_url(app, app_token_info)
-
-        # Validate required keys for token creation
-        _validate_token_creation_keys(app_token_info)
-
-        # Merge with default arguments
-        default_args = {**NEW_CENTRAL_C_DEFAULT_ARGS, **app_token_info}
-        apps_token_info[app] = default_args
-
-    if not apps_token_info:
+    if not token_info:
         raise ValueError(
             f"No valid token information provided. Supported apps: {', '.join(SUPPORTED_APPS)}"
         )
+
+    apps_token_info = {}
+
+    # Unified credentials supersede standalone glp/new_central — warn then discard them
+    if "unified" in token_info:
+        overridden = [k for k in token_info if k in ("glp", "new_central")]
+        if overridden:
+
+            warnings.warn(
+                f"'unified' credentials were provided alongside {overridden}. "
+                f"The {overridden} entries will be ignored; 'unified' takes precedence.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+        unified = dict(token_info["unified"])
+
+        # GLP is always the primary endpoint
+        unified["glp_base_url"] = valid_url(
+            unified.get("glp_base_url", GLP_URLS["BaseURL"])
+        )
+
+        _validate_token_creation_keys("unified", unified)
+
+        unified["base_url"] = _resolve_base_url("unified", unified)
+        unified.pop("cluster_name", None)
+
+        # Precompute token URL for token creation/refresh
+        if unified.get("workspace_id"):
+            unified["_token_url"] = (
+                f"{AUTHENTICATION['OAUTH_GLOBAL']}/{unified['workspace_id']}/token"
+            )
+
+        apps_token_info["unified"] = {**UNIFIED_DEFAULT_ARGS, **unified}
+
+    else:
+        for app, app_token_info in token_info.items():
+            if app not in SUPPORTED_APPS:
+                raise ValueError(
+                    f"Unknown app name '{app}' provided. Supported apps: {', '.join(SUPPORTED_APPS)}"
+                )
+
+            app_token_info["base_url"] = _resolve_base_url(app, app_token_info)
+            _validate_token_creation_keys(app, app_token_info)
+            app_token_info["_token_url"] = AUTHENTICATION["OAUTH"]
+            apps_token_info[app] = {**NEW_CENTRAL_C_DEFAULT_ARGS, **app_token_info}
 
     return apps_token_info
 
 
 def load_token_info(token_info):
-    """Load token information from a file if it's a string path, or return the dictionary as is.
+    """
+    Load token information from a file if it's a string path, or return the dictionary as is.
 
     Args:
         token_info (dict or str): Either a dictionary containing token information or a
@@ -95,83 +141,97 @@ def load_token_info(token_info):
             token_info = parse_input_file(token_info)
         except (ValueError, FileNotFoundError) as e:
             # Re-raise the exception with additional context
-            raise type(e)(f"Failed to load token information: {str(e)}")
+            raise type(e)(f"Failed to load token information: {e}") from e
     return token_info
 
 
+def _resolve_central_base_url(app, app_token_info, required=True):
+    """Resolve a Central base_url from cluster_name or base_url for the given app."""
+    if "cluster_name" in app_token_info and "base_url" in app_token_info:
+        raise ValueError(
+            f"You cannot provide both 'cluster_name' and 'base_url' for {app}. Please provide only one."
+        )
+    if "cluster_name" in app_token_info:
+        cluster_name = app_token_info["cluster_name"]
+        if cluster_name in CLUSTER_BASE_URLS:
+            return CLUSTER_BASE_URLS[cluster_name]
+        raise ValueError(
+            f"Invalid cluster_name '{cluster_name}' provided. Supported clusters: {', '.join(CLUSTER_BASE_URLS.keys())}"
+        )
+    if "base_url" in app_token_info:
+        return valid_url(app_token_info["base_url"])
+    if required:
+        raise ValueError(
+            f"For {app}, either 'cluster_name' or 'base_url' must be provided."
+        )
+    return None
+
+
 def _resolve_base_url(app, app_token_info):
-    """Resolve the base_url using cluster_name or validate the provided base_url.
+    """
+    Resolve the base_url using cluster_name or validate the provided base_url.
 
     Args:
-        app (str): Name of the application (e.g., "new_central", "glp").
+        app (str): Name of the application (e.g., "new_central", "glp", "unified").
         app_token_info (dict): Token information for a specific app.
 
     Returns:
-        (str): Validated or resolved base_url.
+        (str): Validated or resolved base_url, or None if optional and not provided.
 
     Raises:
-        ValueError: If both cluster_name and base_url are provided or neither is valid.
+        ValueError: If both cluster_name and base_url are provided or a required one is missing.
     """
     if app == "new_central":
-        if "cluster_name" in app_token_info and "base_url" in app_token_info:
-            raise ValueError(
-                "You cannot provide both 'cluster_name' and 'base_url' for new_central. Please provide only one."
-            )
-        if "cluster_name" in app_token_info:
-            cluster_name = app_token_info["cluster_name"]
-            if cluster_name in CLUSTER_BASE_URLS:
-                return CLUSTER_BASE_URLS[cluster_name]
-            else:
-                raise ValueError(
-                    f"Invalid cluster_name '{cluster_name}' provided. Supported clusters: {', '.join(CLUSTER_BASE_URLS.keys())}"
-                )
-        if "base_url" in app_token_info:
-            resolved = valid_url(app_token_info["base_url"])
-            known_urls = {u.rstrip("/") for u in CLUSTER_BASE_URLS.values()}
-            if resolved.rstrip("/") not in known_urls:
-                warnings.warn(
-                    f"'{resolved}' is not a recognised Central cluster URL. "
-                    f"Known clusters: {', '.join(CLUSTER_BASE_URLS.keys())}. "
-                    "Proceeding anyway. This is expected for non-production Central clusters",
-                    UserWarning,
-                    stacklevel=4,
-                )
-            return resolved
-        raise ValueError(
-            "For new_central, either 'cluster_name' or 'base_url' must be provided."
-        )
+        return _resolve_central_base_url(app, app_token_info, required=True)
     elif app == "glp":
         if "base_url" not in app_token_info:
             app_token_info["base_url"] = GLP_URLS["BaseURL"]
         return valid_url(app_token_info["base_url"])
+    elif app == "unified":
+        return _resolve_central_base_url(app, app_token_info, required=False)
     else:
-        raise ValueError(f"Unsupported app '{app}'.")
+        raise ValueError(
+            f"_resolve_base_url does not handle '{app}' directly. "
+            "Only 'new_central', 'glp', and 'unified' are valid inputs."
+        )
 
 
-def _validate_token_creation_keys(app_token_info):
-    """Validate that the required keys for token creation are present.
+def _validate_token_creation_keys(app, app_token_info):
+    """
+    Validate that the required keys for token creation are present.
 
     Args:
+        app (str): Name of the application (e.g., "new_central", "glp", "unified").
         app_token_info (dict): Token information for a specific app.
 
     Raises:
-        ValueError: If required keys are missing.
+        ValueError: If required keys are missing or invalid keys are provided.
 
     Note:
         Internal SDK function
     """
-    if "access_token" not in app_token_info:
-        required_keys = {"client_id", "client_secret"}
+    # For unified mode, client credentials and workspace_id are always
+    # required because they are needed for token refresh even when an
+    # existing access_token is supplied.
+    if app == "unified" or "access_token" not in app_token_info:
+        required_keys = APP_TOKEN_CREATION_REQUIRED_KEYS[app]
         missing_keys = required_keys - app_token_info.keys()
         if missing_keys:
             raise ValueError(
-                f"Missing required keys for token creation: {', '.join(missing_keys)}. "
-                "Provide either a valid access token or the required credentials (client_id, client_secret) needed to generate an access token."
+                f"Missing required keys for token creation for '{app}': {', '.join(missing_keys)}. "
+                "Provide either a valid access token or the required credentials to generate an access token."
             )
+    if "access_token" in app_token_info and not isinstance(
+        app_token_info["access_token"], str
+    ):
+        raise ValueError(
+            f"'access_token' for '{app}' must be a string. Got {type(app_token_info['access_token']).__name__} instead."
+        )
 
 
-def build_url(base_url, path="", params="", query={}, fragment=""):
-    """Construct a complete URL based on multiple parts of the URL.
+def build_url(base_url, path="", params="", query=None, fragment=""):
+    """
+    Construct a complete URL based on multiple parts of the URL.
 
     Args:
         base_url (str): Base URL for an HTTP request.
@@ -187,13 +247,16 @@ def build_url(base_url, path="", params="", query={}, fragment=""):
     parsed_baseurl = urlparse(base_url)
     scheme = parsed_baseurl.scheme
     netloc = parsed_baseurl.netloc
+
+    query = query or {}
     query = urlencode(query)
     url = urlunparse((scheme, netloc, path, params, query, fragment))
     return url
 
 
 def console_logger(name, level="DEBUG"):
-    """Create an instance of python logging with a formatted output.
+    """
+    Create an instance of python logging with a formatted output.
 
     Sets the following format for log messages: `<date> <time> - <name> - <level> - <message>`
 
@@ -206,11 +269,10 @@ def console_logger(name, level="DEBUG"):
         (logging.Logger): An instance of the logging.Logger class.
     """
     channel_handler = logging.StreamHandler()
-    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     date_format = "%Y-%m-%d %H:%M:%S"
-    f = format
     if COLOR:
-        cformat = "%(log_color)s" + format
+        cformat = "%(log_color)s" + log_format
         f = colorlog.ColoredFormatter(
             cformat,
             date_format,
@@ -223,11 +285,11 @@ def console_logger(name, level="DEBUG"):
             },
         )
     else:
-        f = logging.Formatter(format, date_format)
+        f = logging.Formatter(log_format, date_format)
     channel_handler.setFormatter(f)
 
     logger = logging.getLogger(name)
-    logger.setLevel(C_LOG_LEVEL[level])
+    logger.setLevel(level)
 
     # Only add Handler if not already present
     if not logger.handlers:
@@ -237,7 +299,8 @@ def console_logger(name, level="DEBUG"):
 
 
 def valid_url(url):
-    """Verify and return the URL in a valid format.
+    """
+    Verify and return the URL in a valid format.
 
     If the URL is missing the https prefix, the function will prepend the prefix
     after verifying that it's a valid base URL of an HPE Aruba Networking Central cluster.
@@ -260,14 +323,12 @@ def valid_url(url):
         )
         return parsed_url.geturl()
     else:
-        errorMessage = (
-            "Invalid Base URL - " + f"{url}\n" + URL_BASE_ERR_MESSAGE
-        )
-        raise ValueError(errorMessage)
+        raise ValueError(f"Invalid Base URL - {url}\n{URL_BASE_ERR_MESSAGE}")
 
 
 def save_access_token(app_name, access_token, token_file_path, logger):
-    """Update the access token for a specific application in the credentials file.
+    """
+    Update the access token for a specific application in the credentials file.
 
     Args:
         app_name (str): Name of the application to update (e.g., "new_central", "glp").
@@ -281,13 +342,12 @@ def save_access_token(app_name, access_token, token_file_path, logger):
         IOError: If there is an error writing to the credentials file.
     """
     if not os.path.isfile(token_file_path):
-        raise FileNotFoundError(
-            f"Credentials file not found: {token_file_path}"
-        )
+        raise FileNotFoundError(f"Credentials file not found: {token_file_path}")
 
     # Load credentials file using existing helper function
     file_data = parse_input_file(token_file_path)
-    is_json = token_file_path.endswith(".json")
+    _, ext = os.path.splitext(token_file_path)
+    is_json = ext.lower() == ".json"
 
     # Update the access token for the specified app
     if app_name not in file_data:
@@ -305,5 +365,5 @@ def save_access_token(app_name, access_token, token_file_path, logger):
             logger.info(
                 f"Successfully saved {app_name}'s access token in {token_file_path}"
             )
-    except Exception as e:
-        raise IOError(f"Failed to write updated credentials to file: {e}")
+    except OSError as e:
+        raise OSError(f"Failed to write updated credentials to file: {e}") from e

--- a/pycentral/utils/constants.py
+++ b/pycentral/utils/constants.py
@@ -53,8 +53,11 @@ SUPPORTED_CONFIG_PERSONAS = {
     "Hybrid NAC": "HYBRID_NAC",
 }
 
-AUTHENTICATION = {"OAUTH": "https://sso.common.cloud.hpe.com/as/token.oauth2"}
-
+AUTHENTICATION = {
+    "OAUTH": "https://sso.common.cloud.hpe.com/as/token.oauth2",
+    # This is te token issuer URL used for unified credential management
+    "OAUTH_GLOBAL": "https://global.api.greenlake.hpe.com/authorization/v2/oauth2",
+}
 GLP_URLS = {
     "BaseURL": "https://global.api.greenlake.hpe.com",
     "DEVICE": "devices",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pycentral"
 dynamic = ["version"]
 description = "HPE Aruba Networking Central Python Package"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "aruba-automation", email = "aruba-automation@hpe.com" }]
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
@@ -25,7 +25,7 @@ dependencies = [
     "protobuf==6.33.5",
     "websocket-client==1.9.0",
     "httpx[http2]==0.28.1",
-    "requests==2.32.5"
+    "requests==2.33.0"
 ]
 [project.optional-dependencies]
 colorLog = ["colorlog"]


### PR DESCRIPTION
This release introduces unified credential support for GLP and New Central API calls, refines token initialization and refresh behavior, updates authentication guidance, and refreshes package requirements for the 2.0a18 release.

### New Features

- **Unified Credential Support**
  - Added a new `unified` credential model that allows one GLP credential set to be used for both GLP and New Central API calls
  - Unified mode uses GLP `client_id`, `client_secret`, and `workspace_id` to generate a single token and reuse it across supported platform requests
  - Supports GLP-only usage when no Central `base_url` or `cluster_name` is provided
  - When `unified` credentials are present, standalone `glp` and `new_central` entries are ignored in favor of the unified configuration

### Improvements

- Added support for the global OAuth token issuer flow used by unified credential management
- Refactored token parsing and route initialization to better support shared-token behavior across GLP and New Central
- Improved token creation and refresh error handling with clearer validation and more actionable failures for invalid credentials or incomplete configuration
- Updated authentication documentation with unified credential guidance, required fields, and example configurations
- Updated package requirements in `pyproject.toml`, including Python version support and the pinned `requests` dependency to patch security vulnerability