### PR TITLE
v2.0a19

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,51 @@
+# 2.0a19
+
+This release introduces MSP tenant connection management, a new Switches monitoring module, expanded troubleshooting event capabilities, ISO location validation for site creation, and refactored shared monitoring utilities.
+
+### New Features
+
+- **MSP Tenant Connection Support**
+  - Added `MSPBase` class — a `NewCentralBase` subclass for Managed Service Provider workflows
+  - `get_tenant_connection(tenant_name, tenant_workspace_id)` performs an RFC 8693 token exchange and returns an isolated `TenantBase` connection scoped to a specific tenant's Central environment
+  - Tenant connections are cached internally; repeat calls with the same `tenant_workspace_id` return the same `TenantBase` instance without re-running the exchange
+  - `close_tenant_connection(tenant_workspace_id)` closes a single cached tenant connection
+  - `get_tenant_id(tenant_name)` resolves a tenant display name to its GLP workspace ID
+  - Added `TenantBase` class that overrides `_renew_token()` to re-exchange the MSP parent token automatically when a tenant-scoped token expires
+- **Switches Monitoring Module**
+  - Added `MonitoringSwitches` class with the following methods:
+    - `get_all_switches`, `get_switches` — paginated switch retrieval with filter and sort support
+    - `get_switch_details` — fetch details for a specific switch by serial number
+    - `get_stack_members` — retrieve stack members for a stacked switch
+    - `get_switch_hardware_categories` — hardware category data for a switch
+    - `get_switch_lag` — LAG (Link Aggregation Group) information
+    - `get_switch_interfaces` — interface list with optional filtering and pagination
+    - `get_switch_vlans` — VLAN membership data for a switch
+    - `get_topn_interface_trends` — top-N interface utilization trends
+    - `get_switch_interface_trends` — per-interface trend data over a time range
+    - `get_switch_hardware_trends` — hardware utilization trends (CPU, memory, etc.)
+    - `get_switch_interface_poe` — PoE usage data per interface
+    - `get_switch_vsx` — VSX (Virtual Switching Extension) state for a switch
+- **Troubleshooting Event Enhancements**
+  - Added `list_event_filters` method to `Troubleshooting` and `Device` classes to retrieve available event filter options
+  - Added `get_event_extra_attributes` method to fetch additional metadata fields for a specific event type
+  - `list_events` now accepts an optional `duration` parameter for time-range based filtering
+- **ISO Location Validation for Site Creation**
+  - `Site.create_site()` now validates `country`, `state`, and `city` inputs against ISO 3166 standards via the new `validate_iso_location` utility before submitting the API request
+  - Added `pycountry` dependency (`26.2.16`) to support ISO validation
+
+### Improvements
+
+- Extracted `validate_device_serial`, `validate_central_conn_and_serial`, `generate_timestamp_str`, and `clean_switch_trend_data` from per-module private helpers into shared `monitoring_utils` so APs, Gateways, and Switches all use the same validation path
+- Added `_renew_token()` hook to `NewCentralBase` — subclasses can now override token renewal behavior without patching `command()`
+- `LoginError` and `ValueError` are now re-raised directly from `command()` instead of being wrapped in `ResponseError`, making authentication failures easier to catch programmatically
+- Improved error message when token creation does not return an `access_token`, providing clearer guidance on verifying client credentials and token URL
+- HTTP client close failures are now logged at `ERROR` level instead of `DEBUG`
+- Updated `requests` dependency from `2.32.5` to `2.33.0`
+- Updated Switches monitoring documentation in `docs/modules/new_monitoring.md`
+- Added full MSP module documentation in `docs/modules/msp.md`
+
+Full Changelog: [v2.0a18...v2.0a19](https://github.com/aruba/pycentral/compare/v2.0a18...v2.0a19)
+
 # 2.0a18
 
 This release introduces unified credential support for GLP and New Central API calls, refines token initialization and refresh behavior, updates authentication guidance, and refreshes package requirements for the 2.0a18 release.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,7 +40,6 @@ This release introduces MSP tenant connection management, a new Switches monitor
 - `LoginError` and `ValueError` are now re-raised directly from `command()` instead of being wrapped in `ResponseError`, making authentication failures easier to catch programmatically
 - Improved error message when token creation does not return an `access_token`, providing clearer guidance on verifying client credentials and token URL
 - HTTP client close failures are now logged at `ERROR` level instead of `DEBUG`
-- Updated `requests` dependency from `2.32.5` to `2.33.0`
 - Updated Switches monitoring documentation in `docs/modules/new_monitoring.md`
 - Added full MSP module documentation in `docs/modules/msp.md`
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -14,53 +14,12 @@ PyCentral supports two authentication methods for New Central & GLP:
 If you want a hassle-free setup use **Client ID & Secret**, the SDK will automatically generate a new token whenever required. 
 If you're just testing an API, using **Access Token** is fine
 
-## New Central
-
-**Base URL or Cluster Name (Choose one)**
-Identifies your Central Account's API gateway. Both options function identically. Use whichever is convenient:
-
-- Base URL
-    Base of the URL for requests to your Central API Gateway. For instructions on how to locate your Base URL, see [Finding Your Base URL in Central](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#finding-your-base-url).
-- Cluster Name
-    Name of the cluster where your account is provisioned. A table detailing all cluster names can be found [here](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#api-gateway-base-urls).
-
-
-**API Credentials** (Choose one):
-
-- Client ID & Client Secret _(Recommended)_  
-    The SDK automatically generates new tokens when they expire, so you don't have to manage them manually. Learn how to create your credentials [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#create-client-credentials).
-- Access Token  
-    Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#generate-access-token). **(Tokens expire in 2 hours)**
-
-## GLP
-
-**No Base URL Required**   
-**API Credentials** (Choose one):
-
-- Client ID & Client Secret _(Recommended)_  
-    The SDK automatically generates new tokens when they expire, so you don't have to manage them manually. Get your credentials [here](https://developer.greenlake.hpe.com/docs/greenlake/guides/public/authentication/authentication/#creating-a-personal-api-client).
-- Access Token  
-    Manually, retrieve an access token [here](https://developer.greenlake.hpe.com/docs/greenlake/guides/public/authentication/authentication/#generating-an-access-token)** (Tokens expire in 15 mins)**
-
-## Classic Central
-
-Classic Central suppports authentication methods for access tokens or generating through OAUTH APIs
-
-**Base URL**  
-   You can find your Classic Central account's base URL from the table provided within this guide [here](https://developer.arubanetworks.com/central/docs/api-oauth-access-token#table-domain-urls-for-api-gateway-access).
-
-**API Credentials** (Choose one):
-
-- OAUTH
-
-    Manually, use the pycentral.workflows_utils.get_conn_from_file() function to generate new tokens when they expire. View our Classic Central guide for OAUTH Authentication with PyCentral [here](https://developer.arubanetworks.com/central/docs/python-using-api-sdk#arubacentralbase-class-requirements).
-
-- Access Token  
-    Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/central/docs/api-gateway-creating-application-token). **(Tokens expire in 2 hours)**
-
 ## Unified Credentials
 
 PyCentral also supports a **unified credential** model. Instead of providing separate `glp` and `new_central` credential blocks, you provide one `unified` block using your GLP client credentials. The SDK generates one token through GLP auth (using `workspace_id`) and reuses that same token for both GLP and New Central API calls.
+
+!!! note "MSP Mode Requires Unified Credentials"
+    MSP mode only supports `unified` credentials. See the [MSP guide](../modules/msp.md) for setup details and usage.
 
 ### How It Works
 
@@ -106,6 +65,50 @@ token_info = {
 ```
 
 This enables GLP APIs only. Add `base_url` or `cluster_name` to also enable New Central APIs.
+
+## New Central
+
+**Base URL or Cluster Name (Choose one)**
+Identifies your Central Account's API gateway. Both options function identically. Use whichever is convenient:
+
+- Base URL
+    Base of the URL for requests to your Central API Gateway. For instructions on how to locate your Base URL, see [Finding Your Base URL in Central](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#finding-your-base-url).
+- Cluster Name
+    Name of the cluster where your account is provisioned. A table detailing all cluster names can be found [here](https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#api-gateway-base-urls).
+
+
+**API Credentials** (Choose one):
+
+- Client ID & Client Secret _(Recommended)_  
+    The SDK automatically generates new tokens when they expire, so you don't have to manage them manually. Learn how to create your credentials [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#create-client-credentials).
+- Access Token  
+    Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#generate-access-token). **(Tokens expire in 2 hours)**
+
+## GLP
+
+**No Base URL Required**   
+**API Credentials** (Choose one):
+
+- Client ID & Client Secret _(Recommended)_  
+    The SDK automatically generates new tokens when they expire, so you don't have to manage them manually. Get your credentials [here](https://developer.greenlake.hpe.com/docs/greenlake/guides/public/authentication/authentication/#creating-a-personal-api-client).
+- Access Token  
+    Manually, retrieve an access token [here](https://developer.greenlake.hpe.com/docs/greenlake/guides/public/authentication/authentication/#generating-an-access-token)** (Tokens expire in 15 mins)**
+
+## Classic Central
+
+Classic Central suppports authentication methods for access tokens or generating through OAUTH APIs
+
+**Base URL**  
+   You can find your Classic Central account's base URL from the table provided within this guide [here](https://developer.arubanetworks.com/central/docs/api-oauth-access-token#table-domain-urls-for-api-gateway-access).
+
+**API Credentials** (Choose one):
+
+- OAUTH
+
+    Manually, use the pycentral.workflows_utils.get_conn_from_file() function to generate new tokens when they expire. View our Classic Central guide for OAUTH Authentication with PyCentral [here](https://developer.arubanetworks.com/central/docs/python-using-api-sdk#arubacentralbase-class-requirements).
+
+- Access Token  
+    Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/central/docs/api-gateway-creating-application-token). **(Tokens expire in 2 hours)**
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ PyCentral(v2) is the latest version of the SDK, designed for compatibility and s
 
 - Backwards Compatible → Works with PyCentral v1 scripts, with no breaking changes.
 - Multi-Platform Support → Works across Classic Central, New Central, and GLP.
+- Use [MSPBase](modules/msp.md) for MSP-level and tenant-scoped API workflows with unified credentials.
 - Simplified Token Management → Built-in OAuth2.0 support (no manual refresh needed).
 - Simplified Automation → Modules for configuration, monitoring, devices, subscriptions, and troubleshooting.
 
@@ -26,7 +27,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a18/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a10/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
 
 ## Quick Example
 
@@ -72,6 +73,7 @@ Browse the complete module documentation:
 - [Exceptions](modules/scopes.md) - Exceptions used throughout PyCentral
 - [GLP](modules/glp.md) - HPE GreenLake Platform management
 - [Monitoring](modules/new_monitoring.md) - Monitoring modules
+- [MSP](modules/msp.md) - MSP modules
 - [Profiles](modules/profiles.md) - Configuration profile management
 - [Scopes](modules/scopes.md) - Scope management modules
 - [Troubleshooting](modules/troubleshooting.md) - Troubleshooting Modules

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a10/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a19/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/docs/modules/msp.md
+++ b/docs/modules/msp.md
@@ -1,0 +1,189 @@
+# MSP
+
+The MSP module provides `MSPBase`, an extension of `NewCentralBase` designed for Managed Service Providers (MSPs). It handles MSP-level authentication and provides isolated, tenant-scoped API connections through a token-exchange flow — all without managing tokens manually.
+
+!!! note "Unified Credentials Only"
+    MSP features are available starting in PyCentral SDK `v2.0a19`.
+    `MSPBase` exclusively uses `"unified"` credentials. Standalone `"glp"` or `"new_central"` entries are not supported.
+
+## Overview
+
+`MSPBase` builds on `NewCentralBase` and adds:
+
+- **MSP-level GLP and New Central API calls** using a single `"unified"` credential
+- **Per-tenant connections** via `get_tenant_connection()`, which exchanges the MSP token for a tenant-scoped token
+- **Automatic token renewal** — when a token expires (MSP or tenant), the SDK refreshes it transparently
+- **Tenant connection caching** — repeated calls with the same `tenant_workspace_id` return the same connection without re-running the token exchange
+
+***
+
+## Authentication
+
+All MSP connections use a single set of `"unified"` credentials. Provide a `workspace_id` for your MSP workspace, along with your `client_id` and `client_secret`.
+
+To also enable **New Central** API calls (e.g. for monitoring or configuration), include a `cluster_name` **or** a `base_url` for the Central cluster your MSP account is provisioned on.
+
+```yaml title="msp_token.yaml"
+unified:
+  client_id: <client-id>
+  client_secret: <client-secret>
+  workspace_id: <workspace-id>
+  cluster_name: US-WEST-5   # Optional — include to enable New Central API calls
+```
+***
+
+## Basic Setup
+
+### MSP-Level API Calls
+
+Once you have the `msp_token.yaml` file ready, you can make MSP-level API calls to both New Central and GLP.
+
+```python title="msp_api_calls.py"
+from pycentral import MSPBase
+
+with MSPBase(token_info="msp_token.yaml") as msp:
+    # New Central API call — list MSP tenants
+    response = msp.command(
+            api_method="GET",
+            api_path="network-msp/v1/list-tenants",
+            api_params={"limit": 100, "next": 1},
+    )
+
+    if response["code"] == 200:
+        tenants = response["msg"].get("items", [])
+        print(f"Total tenants: {len(tenants)}")
+        for tenant in tenants:
+            print(f'Central Tenant ID - {tenant.get("tenantId")}, Tenant Name - {tenant.get("tenantName")}')
+    else:
+        print(f"Error {response['code']}: {response['msg']}")
+```
+
+!!! note "GLP-Only Mode"
+    If you only need GLP API calls (e.g. listing tenants, managing subscriptions), omit `cluster_name` / `base_url` from your credentials. Only the GLP endpoint will be configured.
+
+***
+
+## Tenant Connections
+
+`get_tenant_connection()` exchanges the MSP token for a tenant-scoped token and returns a connection that behaves exactly like `NewCentralBase`. Use it for all tenant-scoped API calls.
+
+The connection is cached — calling `get_tenant_connection()` again with the same `tenant_workspace_id` returns the same object without repeating the token exchange.
+
+!!! note "Tenant Workspace ID"
+    `tenant_workspace_id` is the GLP workspace ID for the tenant. This is an ID from GLP for the tenant similar to the `workspace_id` in your MSP credentials, but scoped to the individual tenant. It can be found in the `tenantId` field of the GLP tenant list response. The SDK automatically strips dashes from the value (e.g. `"abc-def-123"` becomes `"abcdef123"`) to match GLP API requirements. This normalization is applied consistently across `get_tenant_connection()` and `close_tenant_connection()`.
+
+### Create a Tenant Connection
+
+You can create a tenant connection by providing either a `tenant_workspace_id` or a `tenant_name`. When using `tenant_name`, the SDK resolves it to a `tenant_workspace_id` via a GLP API call.
+
+```python title="tenant_connection.py"
+from pycentral import MSPBase
+
+with MSPBase(token_info="msp_token.yaml") as msp:
+    # Option 1: Connect by tenant workspace ID (from the GLP tenant list)
+    tenant_conn = msp.get_tenant_connection(tenant_workspace_id="<tenant-workspace-id>")
+
+    # Option 2: Connect by tenant name (resolves to workspace ID via GLP API)
+    # tenant_conn = msp.get_tenant_connection(tenant_name="<tenant-name>")
+```
+
+### Tenant — New Central API Call
+
+The tenant connection inherits the same Central base URL from the MSP credentials. Provide `cluster_name` or `base_url` in your MSP credentials to enable New Central calls.
+
+```python title="tenant_new_central.py"
+from pycentral import MSPBase
+
+with MSPBase(token_info="account_credentials_new.yaml") as msp:
+        tenant_conn = msp.get_tenant_connection(tenant_workspace_id="<tenant-workspace-id>")
+
+        # List APs in the tenant's Central environment
+        response = tenant_conn.command(
+            api_method="GET",
+            api_path="network-monitoring/v1/aps",
+        )
+        if response["code"] == 200:
+            aps = response["msg"].get("items", [])
+            print(f"Tenant APs: {len(aps)}")
+            for ap in aps:
+                print(ap.get("serialNumber"), ap.get("deviceName"), ap.get("status"))
+        else:
+            print(f"Error {response['code']}: {response['msg']}")
+```
+
+### Tenant — GLP API Call
+
+Use the tenant connection to make GLP calls scoped to that tenant's workspace.
+
+```python title="tenant_glp.py"
+from pycentral import MSPBase
+
+ with MSPBase(token_info="account_credentials_new.yaml") as msp:
+    tenant_conn = msp.get_tenant_connection(tenant_name="The Wandwright Academy")
+
+    # Specify app_name="glp" to make API call to GreenLake.
+    response = tenant_conn.command(
+        api_method="GET",
+        api_path="audit-log/v1/logs",
+        app_name="glp",
+    )
+
+    if response["code"] == 200:
+        logs = response["msg"].get("items", [])
+        print(f"Tenant audit logs: {len(logs)}")
+        for log in logs:
+            print(log.get("createdAt"), log.get("category"), log.get("user"))
+    else:
+        print(f"Error {response['code']}: {response['msg']}")
+```
+
+***
+
+## Token Renewal
+
+Token renewal is handled automatically by the SDK. No manual intervention is required.
+
+| Scenario | What Happens |
+| :--- | :--- |
+| MSP token expires during an API call | SDK refreshes the MSP token using client credentials and retries |
+| Tenant token expires during an API call | SDK refreshes the MSP parent token first, then re-exchanges it for a fresh tenant-scoped token, and retries |
+| MSP token expires during tenant token exchange | SDK renews the MSP token and retries the exchange (up to one retry) |
+
+***
+
+## Managing Connections
+
+Both `MSPBase` and tenant connections support Python's `with` statement, which ensures all HTTP clients are closed cleanly when the block exits.
+
+```python title="manage_connections.py"
+from pycentral import MSPBase
+
+with MSPBase(token_info="msp_token.yaml") as msp:
+    tenant_conn = msp.get_tenant_connection(tenant_workspace_id="<tenant-workspace-id>")
+
+    # Use tenant_conn for API calls...
+
+    # Optionally close a single tenant connection mid-session
+    msp.close_tenant_connection(tenant_workspace_id="<tenant-workspace-id>")
+
+# msp.close() is called automatically — closes MSP and all remaining tenant connections
+```
+
+!!! note "Manual Cleanup"
+    If you're not using `with`, call `msp.close()` when done to release HTTP client resources for both the MSP connection and all cached tenant connections.
+
+***
+
+## Next Steps
+
+- Explore the [Base Module Reference](base.md) for `NewCentralBase` details
+- See the [Authentication Guide](../getting-started/authentication.md) for credential setup
+- Explore the full catalog of Central guides on the [Developer Hub](https://developer.arubanetworks.com/new-central/docs/about)
+
+***
+
+## API Reference
+
+::: pycentral.msp.msp_base.MSPBase
+
+::: pycentral.msp.msp_base.TenantBase

--- a/docs/modules/new_monitoring.md
+++ b/docs/modules/new_monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring
 
-Monitoring modules available in the PyCentral SDK are separated by type APs, Clients, Devices, Gateways, and Sites.
+Monitoring modules available in the PyCentral SDK are separated by type APs, Clients, Devices, Gateways, Sites, and Switches.
 
 ---
 
@@ -26,3 +26,8 @@ Monitoring modules available in the PyCentral SDK are separated by type APs, Cli
 
 ## Sites
 ::: pycentral.new_monitoring.sites
+
+---
+
+## Switches
+::: pycentral.new_monitoring.switches

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a18"
+__version__ = "2.0a19"
 
 from .base import NewCentralBase
 from .msp import MSPBase

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -4,7 +4,7 @@
 __version__ = "2.0a18"
 
 from .base import NewCentralBase
-
+from .msp import MSPBase
 # Manually import each module in the legacy Central folder
 import importlib
 import sys

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -197,20 +197,25 @@ class NewCentralBase:
         try:
             self.logger.info(f"Attempting to create new token from {app_name}")
             token = oauth.fetch_token(token_url=token_url, auth=auth)
-            self.logger.debug(f"Token response for {app_name}: {token}")
-            if "access_token" in token:
-                self.logger.info(
-                    f"{app_name} Login Successful.. Obtained Access Token!"
+            if "access_token" not in token:
+                msg = (
+                    f"Token response for '{app_name}' did not contain an access_token. "
+                    "Verify that the client credentials and token URL are correct."
                 )
-                self.token_info[app_name]["access_token"] = token["access_token"]
-                if self.token_file_path:
-                    save_access_token(
-                        app_name,
-                        token["access_token"],
-                        self.token_file_path,
-                        self.logger,
-                    )
-                return token["access_token"]
+                self.logger.error(msg)
+                raise LoginError(msg)
+            self.logger.info(
+                f"{app_name} Login Successful.. Obtained Access Token!"
+            )
+            self.token_info[app_name]["access_token"] = token["access_token"]
+            if self.token_file_path:
+                save_access_token(
+                    app_name,
+                    token["access_token"],
+                    self.token_file_path,
+                    self.logger,
+                )
+            return token["access_token"]
         except Exception as e:
             # unified extraction of status code (from exception or its response)
             status_code = getattr(e, "status_code", None)
@@ -321,7 +326,7 @@ class NewCentralBase:
                     self.logger.info(
                         f"{app_name} access token has expired. Handling Token Expiry..."
                     )
-                    self.create_token(route["token_key"])
+                    self._renew_token(route["token_key"])
                     retry += 1
                 else:
                     break
@@ -345,6 +350,8 @@ class NewCentralBase:
 
             return result
 
+        except (LoginError, ValueError):
+            raise
         except Exception as err:
             err_str = f"{api_method} FAILURE "
             self.logger.error(err)
@@ -518,6 +525,17 @@ class NewCentralBase:
                 self.logger.error(err_str)
                 raise ResponseError(err_str, err)
 
+    def _renew_token(self, token_key):
+        """Renew the access token for the given token_info key.
+
+        Subclasses (e.g. TenantBase) override this to implement
+        custom renewal strategies such as MSP tenant token exchange.
+
+        Args:
+            token_key (str): Key in self.token_info whose token should be renewed.
+        """
+        self.create_token(token_key)
+
     def _validate_request(self, app_name, method):
         """
         Validate that the provided app name is configured and the HTTP method is supported.
@@ -591,7 +609,7 @@ class NewCentralBase:
                 if http_client:
                     http_client.close()
             except Exception as err:
-                self.logger.debug(f"Failed closing HTTP client for {app_name}: {err}")
+                self.logger.error(f"Failed closing HTTP client for {app_name}: {err}")
 
         self._http_clients = {}
 

--- a/pycentral/msp/__init__.py
+++ b/pycentral/msp/__init__.py
@@ -1,0 +1,2 @@
+from .msp_base import MSPBase
+from .tenant_base import TenantBase

--- a/pycentral/msp/msp_base.py
+++ b/pycentral/msp/msp_base.py
@@ -1,0 +1,317 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+# MIT License
+
+"""MSP-aware extension of NewCentralBase.
+
+Use :class:`MSPBase` instead of :class:`NewCentralBase` when operating
+as a Managed Service Provider (MSP).  The class inherits all base functionality
+and adds :meth:`get_tenant_connection`, which performs a tenant-specific token
+exchange and returns an isolated :class:`TenantBase` instance scoped to
+that tenant's environment.
+
+When the tenant connection's access token expires, it automatically renews the
+parent MSP token first and then re-exchanges it for a fresh tenant-scoped token,
+keeping the entire chain in sync through a single renewal path.
+
+Example::
+
+    from pycentral import MSPBase
+
+    msp = MSPBase(
+        token_info={
+            "unified": {
+                "client_id": "<client-id>",
+                "client_secret": "<client-secret>",
+                "workspace_id": "<workspace-id>",
+                "cluster_name": "US-WEST-5",
+            }
+        }
+    )
+
+    # Obtain a scoped connection for a specific tenant
+    tenant_conn = msp.get_tenant_connection(tenant_workspace_id="<tenant-workspace-id>")
+    # Use tenant_conn.command(...) for all tenant-scoped Central API calls
+"""
+
+from oauthlib.oauth2 import BackendApplicationClient
+from oauthlib.oauth2.rfc6749.errors import TokenExpiredError, InvalidClientError
+from requests_oauthlib import OAuth2Session
+from requests.auth import HTTPBasicAuth
+
+from ..base import NewCentralBase
+from ..exceptions import LoginError
+from ..utils import AUTHENTICATION
+from .tenant_base import TenantBase
+
+class MSPBase(NewCentralBase):
+    """
+    NewCentralBase subclass with MSP tenant token-exchange support.
+
+    All constructor arguments are identical to NewCentralBase.
+    MSP mode exclusively uses "unified" credentials so that both GLP and
+    Central API calls share a single token, while per-tenant access is
+    obtained via get_tenant_connection().
+
+    Tenant connections are cached internally: calling get_tenant_connection()
+    with the same tenant_workspace_id multiple times always returns the same
+    TenantBase instance without re-running the token exchange.
+    Use close_tenant_connection() to explicitly close a single tenant connection,
+    or close() (inherited) to close the MSP connection and all cached tenant connections.
+
+    Args:
+        token_info (dict or str): Token information dict or path to a YAML/JSON
+            credentials file. See NewCentralBase for full details.
+        logger (logging.Logger, optional): External logger. Defaults to None.
+        log_level (str, optional): Log level string. Defaults to "INFO".
+        enable_scope (bool, optional): Whether to initialise scope management. Defaults to False.
+    """
+
+    def __init__(self, token_info, logger=None, log_level="INFO", enable_scope=False):
+        # Tenant connection cache: {tenant_workspace_id: TenantBase}
+        # Initialised before super().__init__ so it exists if any subclass hook
+        # were to call get_tenant_connection during initialisation.
+        self._tenant_connections: dict = {}
+        super().__init__(
+            token_info=token_info,
+            logger=logger,
+            log_level=log_level,
+            enable_scope=enable_scope,
+        )
+
+    def _get_msp_access_token(self):
+        """
+        Return the current MSP-level Central access token.
+
+        Reads access_token from the unified token_info entry, which is
+        the only supported token management method for MSP mode.
+
+        Returns:
+            (str or None): The current MSP access token for Central calls.
+
+        Note:
+            Internal SDK function
+        """
+
+        return self.token_info["unified"].get("access_token")
+
+    def _exchange_tenant_token(self, tenant_workspace_id: str) -> str:
+        """
+        Exchange the current MSP access token for a tenant-scoped token (RFC 8693).
+
+        If the MSP token is expired, it is renewed automatically and the exchange
+        is retried once. Both get_tenant_connection() and
+        TenantBase.handle_expired_token() delegate here.
+
+        Args:
+            tenant_workspace_id (str): The tenant's GLP workspace ID, used as the
+                audience in the token exchange URL.
+
+        Returns:
+            (str): The tenant-scoped Central access token.
+
+        Raises:
+            LoginError: If MSP token renewal or the token exchange fails.
+
+        Note:
+            Internal SDK function
+        """
+        client_id, client_secret = self._return_client_credentials("unified")
+        client = BackendApplicationClient(client_id)
+        client.grant_type = "urn:ietf:params:oauth:grant-type:token-exchange"
+        oauth = OAuth2Session(client=client)
+        auth = HTTPBasicAuth(client_id, client_secret)
+        token_url = f"{AUTHENTICATION['OAUTH_GLOBAL']}/{tenant_workspace_id}/token"
+        fetch_kwargs = dict(
+            token_url=token_url,
+            auth=auth,
+            subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+        )
+
+        for attempt in range(2):
+            try:
+                token = oauth.fetch_token(
+                    subject_token=self._get_msp_access_token(), **fetch_kwargs
+                )
+                self.logger.debug(
+                    f"Tenant token exchange response for tenant_workspace_id='{tenant_workspace_id}': {token}"
+                )
+                return token["access_token"]
+            except (TokenExpiredError, InvalidClientError):
+                if attempt >= 1:
+                    msg = (
+                        f"Failed to exchange tenant token for tenant_workspace_id='{tenant_workspace_id}' "
+                        "after MSP token renewal."
+                    )
+                    self.logger.error(msg)
+                    raise LoginError(msg)
+                self.logger.info(
+                    f"MSP token expired during tenant exchange for '{tenant_workspace_id}'. "
+                    "Renewing and retrying..."
+                )
+                self.create_token("unified")
+            except Exception as e:
+                msg = f"Failed to exchange tenant token for tenant_workspace_id='{tenant_workspace_id}': {e}"
+                self.logger.error(msg)
+                raise LoginError(msg)
+
+    def get_tenant_connection(
+        self, tenant_name=None, tenant_workspace_id=None
+    ) -> TenantBase:
+        """
+        Obtain a tenant-scoped connection for the given tenant.
+
+        Returns a cached TenantBase if one already exists for
+        tenant_workspace_id. Otherwise performs the token exchange, creates a
+        new connection, caches it, and returns it.
+
+        Token expiry is handled automatically: when a cached connection receives
+        a 401, it renews the MSP parent token and re-exchanges it for a fresh
+        tenant token without any additional caller action.
+
+        Args:
+            tenant_name (str, optional): The display name of the MSP tenant.
+            tenant_workspace_id (str, optional): The tenant's GLP workspace ID,
+                used as the subject in the token exchange request. Find this in
+                the GLP tenant list response (``tenantId`` field).
+
+        Returns:
+            (TenantBase): A connection instance scoped to the specified
+                tenant's Central environment. Use its command() method for all
+                tenant-scoped API calls. The same object is returned on subsequent
+                calls with the same tenant_workspace_id.
+
+        Raises:
+            ValueError: If neither tenant_name nor tenant_workspace_id is provided,
+                or if Central is not configured on this MSP instance (no cluster_name
+                or base_url under "unified", and no standalone "glp" entry).
+            LoginError: If MSP token renewal or the token exchange fails.
+        """
+        if tenant_workspace_id is None and tenant_name is None:
+            raise ValueError("Either 'tenant_workspace_id' or 'tenant_name' must be provided.")
+
+        if tenant_name:
+            tenant_workspace_id = self.get_tenant_id(tenant_name)
+
+        if type(tenant_workspace_id) is not str:
+            raise ValueError("tenant_workspace_id must be a string.")
+        # Normalize tenant_workspace_id by removing dashes as per GLP API requirements
+        tenant_workspace_id = tenant_workspace_id.replace("-", "")
+        # Return cached connection if it already exists
+        if tenant_workspace_id in self._tenant_connections:
+            self.logger.debug(
+                f"Returning cached tenant connection for tenant_workspace_id='{tenant_workspace_id}'"
+            )
+            return self._tenant_connections[tenant_workspace_id]
+
+        self.logger.info(f"Creating new tenant connection for tenant_workspace_id='{tenant_workspace_id}'")
+
+        # Exchange the MSP token for a tenant-scoped token
+        tenant_access_token = self._exchange_tenant_token(tenant_workspace_id)
+
+        # Build a minimal token_info for the tenant connection using unified mode
+        # (no client credentials needed — renewal delegates back to this MSP instance).
+        tenant_token_info = {
+            "unified": {
+                "glp_base_url": self.token_info["unified"].get("glp_base_url"),
+                "base_url": self.token_info["unified"].get("base_url"),
+                "access_token": tenant_access_token,
+            },
+        }
+
+        conn = TenantBase(
+            token_info=tenant_token_info,
+            msp_parent=self,
+            tenant_workspace_id=tenant_workspace_id,
+            logger=self.logger,
+        )
+        self._tenant_connections[tenant_workspace_id] = conn
+        self.logger.info(f"Tenant connection for '{tenant_workspace_id}' established and cached.")
+        return conn
+
+    def close_tenant_connection(self, tenant_workspace_id: str) -> None:
+        """
+        Close and evict the cached connection for a specific tenant.
+
+        Releases the underlying HTTP client resources for the given tenant and
+        removes it from the cache. The next call to get_tenant_connection() with
+        the same tenant_workspace_id will perform a fresh token exchange.
+
+        Args:
+            tenant_workspace_id (str): The tenant's GLP workspace ID whose
+                cached connection should be closed.
+
+        Raises:
+            KeyError: If no cached connection exists for tenant_workspace_id.
+        """
+        tenant_workspace_id = tenant_workspace_id.replace("-", "")
+        if tenant_workspace_id not in self._tenant_connections:
+            raise KeyError(
+                f"No cached tenant connection found for tenant_workspace_id='{tenant_workspace_id}'. "
+                "Use get_tenant_connection() to create one first."
+            )
+        conn = self._tenant_connections.pop(tenant_workspace_id)
+        try:
+            conn.close()
+        except Exception as err:
+            self.logger.debug(
+                f"Error closing HTTP clients for tenant '{tenant_workspace_id}': {err}"
+            )
+        self.logger.info(f"Tenant connection for '{tenant_workspace_id}' closed.")
+
+    def close(self) -> None:
+        """
+        Close the MSP connection and all cached tenant connections.
+
+        Closes every cached TenantBase first, then closes the
+        MSP-level HTTP clients inherited from NewCentralBase.
+        """
+        for tenant_workspace_id in list(self._tenant_connections):
+            try:
+                self._tenant_connections[tenant_workspace_id].close()
+            except Exception as err:
+                self.logger.debug(
+                    f"Error closing tenant connection '{tenant_workspace_id}' during MSP close: {err}"
+                )
+        self._tenant_connections.clear()
+        super().close()
+
+    def get_tenant_id(self, tenant_name):
+        """
+        Resolve a tenant display name to its GLP workspace ID.
+
+        Queries the GLP MSP tenants API and returns the workspace ID for the
+        given tenant name. This workspace ID is required for the token exchange
+        performed by get_tenant_connection().
+
+        Args:
+            tenant_name (str): The display name of the tenant to resolve.
+
+        Returns:
+            (str): The tenant's GLP workspace ID.
+
+        Raises:
+            ValueError: If the tenant_name cannot be resolved to a workspace ID.
+        """
+        api_path = "workspaces/v1/msp-tenants"
+        api_method = "GET"
+        safe_name = tenant_name.replace("'", "''")
+        api_params = {"filter": f"workspaceName eq '{safe_name}'"}
+        response = self.command(
+            api_method=api_method,
+            api_path=api_path,
+            app_name="glp",
+            api_params=api_params,
+        )
+        if response["code"] != 200:
+            raise ValueError(
+                f"Failed to retrieve tenants: {response.get('msg', 'No error message provided')}"
+            )
+        response_msg = response.get("msg", {})
+        tenant = response_msg.get("items", [])
+
+        if not tenant:
+            raise ValueError(f"No tenant found with name '{tenant_name}'")
+        if len(tenant) > 1:
+            raise ValueError(f"Multiple tenants found with name '{tenant_name}'")
+        tenant_workspace_id = tenant[0].get("id")
+        return tenant_workspace_id

--- a/pycentral/msp/tenant_base.py
+++ b/pycentral/msp/tenant_base.py
@@ -1,0 +1,83 @@
+
+from ..base import NewCentralBase
+from ..exceptions import LoginError
+
+class TenantBase(NewCentralBase):
+    """
+    A tenant-scoped connection owned by MSPBase.
+
+    Not intended to be instantiated directly — obtain instances via
+    MSPBase.get_tenant_connection().
+
+    On a 401 response, _renew_token() renews the parent MSP's
+    shared token first, then re-exchanges it for a fresh tenant-scoped token,
+    keeping both connections in sync.
+
+    Args:
+        token_info (dict): Pre-built token_info dict, already resolved — bypasses new_parse_input_args.
+        msp_parent (MSPBase): The parent MSP instance that owns this tenant connection.
+        tenant_workspace_id (str): The tenant's GLP workspace ID, used as the subject
+            in the token exchange request.
+        logger (logging.Logger, optional): Shared logger inherited from the parent MSP instance.
+    """
+
+    def __init__(self, token_info, msp_parent, tenant_workspace_id, logger):
+        self._msp_parent = msp_parent
+        self._tenant_workspace_id = tenant_workspace_id
+        # Bypass new_parse_input_args — token_info is already fully resolved.
+        # Directly initialise the minimal NewCentralBase state we need.
+        self.token_info = token_info
+        self.token_file_path = None
+        self.logger = logger
+        self._app_routes = self._build_app_routes()
+        self.scopes = None
+        self._http_clients = {}
+        self._initialize_http_clients()
+
+    def _renew_token(self, token_key):
+        """
+        Renew the MSP parent token then re-exchange for a fresh tenant token.
+
+        Overrides NewCentralBase._renew_token so that command()'s 401 handler
+        uses the MSP tenant renewal chain instead of a direct create_token() call.
+
+        Renewal chain on a 401:
+
+        1. Refresh the parent MSP's unified/new_central token via MSPBase.create_token().
+        2. Re-exchange that fresh MSP token for a new tenant-scoped token via MSPBase._exchange_tenant_token().
+        3. Update this connection's token_info["unified"]["access_token"] with the new tenant token so the next retry uses it.
+
+        Args:
+            token_key (str): The token_info key that received the 401 (always "unified" for tenant connections).
+
+        Raises:
+            LoginError: If the MSP parent token renewal or tenant exchange fails.
+        """
+        self.logger.info(
+            f"Tenant connection for '{self._tenant_workspace_id}' received a 401. "
+            "Renewing MSP parent token then re-exchanging for a fresh tenant token..."
+        )
+
+        # Step 1: renew the MSP parent's unified token
+        try:
+            self._msp_parent.create_token("unified")
+        except LoginError as e:
+            msg = (
+                f"Failed to renew MSP parent token during tenant '{self._tenant_workspace_id}' "
+                f"token refresh: {e}"
+            )
+            self.logger.error(msg)
+            raise LoginError(msg)
+
+        # Step 2: re-exchange the fresh MSP token for a new tenant-scoped token
+        # and update this connection's access token so the retry succeeds.
+        try:
+            new_tenant_token = self._msp_parent._exchange_tenant_token(self._tenant_workspace_id)
+            self.token_info["unified"]["access_token"] = new_tenant_token
+            self.logger.info(
+                f"Tenant token for '{self._tenant_workspace_id}' successfully renewed."
+            )
+        except Exception as e:
+            msg = f"Failed to re-exchange tenant token for '{self._tenant_workspace_id}': {e}"
+            self.logger.error(msg)
+            raise LoginError(msg)

--- a/pycentral/new_monitoring/__init__.py
+++ b/pycentral/new_monitoring/__init__.py
@@ -3,3 +3,4 @@ from .devices import MonitoringDevices
 from .gateways import MonitoringGateways
 from .sites import MonitoringSites
 from .clients import Clients
+from .switches import MonitoringSwitches

--- a/pycentral/new_monitoring/aps.py
+++ b/pycentral/new_monitoring/aps.py
@@ -3,6 +3,7 @@ from ..utils.monitoring_utils import (
     generate_timestamp_str,
     clean_raw_trend_data,
     merged_dict_to_sorted_list,
+    validate_device_serial,
 )
 from ..exceptions import ParameterError
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -104,7 +105,7 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number=serial_number)
+        validate_device_serial(serial_number=serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}"
         return execute_get(central_conn, endpoint=path)
 
@@ -135,7 +136,7 @@ class MonitoringAPs:
             ParameterError: If serial_number is missing/invalid.
             RuntimeError: If any of the parallel metric requests fail.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
 
         # dispatch the three metric calls in parallel; helper methods handle timestamp logic
         funcs = [
@@ -197,7 +198,7 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
         stats = MonitoringAPs.get_ap_stats(
             central_conn, serial_number, duration="5m"
         )
@@ -232,7 +233,7 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}/cpu-utilization-trends"
         if start_time is None and end_time is None and duration is None:
             return execute_get(central_conn, endpoint=path)
@@ -273,7 +274,7 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}/memory-utilization-trends"
         if start_time is None and end_time is None and duration is None:
             return execute_get(
@@ -317,7 +318,7 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}/power-consumption-trends"
         if start_time is None and end_time is None and duration is None:
             return execute_get(
@@ -419,24 +420,8 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        MonitoringAPs._validate_device_serial(serial_number)
+        validate_device_serial(serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}/wlans"
         return execute_get(central_conn, endpoint=path)
 
-    def _validate_device_serial(serial_number):
-        """
-        Validate AP device serial_number.
 
-        Args:
-            serial_number (str): Device serial number to validate.
-
-        Raises:
-            ParameterError: If serial_number is missing or not a string.
-
-        Note:
-            Internal SDK function
-        """
-        if not isinstance(serial_number, str) or not serial_number:
-            raise ParameterError(
-                "serial_number is required and must be a string"
-            )

--- a/pycentral/new_monitoring/clients.py
+++ b/pycentral/new_monitoring/clients.py
@@ -395,8 +395,7 @@ class Clients:
             (dict): Raw API response containing top-N usage data.
 
         Raises:
-            ParameterError: If site_id or site_name is provided but invalid, or
-            if limit is not in range 1..100.
+            ParameterError: If site_id or site_name is provided but invalid, or if limit is not in range 1..100.
         """
         path = "clients-topn-usage"
         if site_id or site_name:

--- a/pycentral/new_monitoring/gateways.py
+++ b/pycentral/new_monitoring/gateways.py
@@ -3,6 +3,7 @@ from ..utils.monitoring_utils import (
     generate_timestamp_str,
     clean_raw_trend_data,
     merged_dict_to_sorted_list,
+    validate_central_conn_and_serial,
 )
 from ..exceptions import ParameterError
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -115,9 +116,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         path = f"{MONITOR_TYPE}/{serial_number}"
         return execute_get(central_conn, endpoint=path, version=API_VERSION)
 
@@ -149,9 +148,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         params = {
             "limit": limit,
             "next": next,
@@ -189,9 +186,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         params = {
             "limit": limit,
             "next": next,
@@ -228,9 +223,7 @@ class MonitoringGateways:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
             RuntimeError: If any of the parallel metric requests fail.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
 
         # dispatch the three metric calls in parallel; helper methods handle timestamp logic
         funcs = [
@@ -293,9 +286,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         stats = MonitoringGateways.get_gateway_stats(
             central_conn, serial_number, duration="5m"
         )
@@ -330,9 +321,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         if start_time is None and end_time is None and duration is None:
             return execute_get(
                 central_conn,
@@ -377,9 +366,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         if start_time is None and end_time is None and duration is None:
             return execute_get(
                 central_conn,
@@ -424,9 +411,7 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
+        validate_central_conn_and_serial(central_conn, serial_number)
         if start_time is None and end_time is None and duration is None:
             return execute_get(
                 central_conn,
@@ -462,30 +447,8 @@ class MonitoringGateways:
         Raises:
             ParameterError: If central_conn is None or serial_number is missing/invalid.
         """
-        MonitoringGateways._validate_central_conn_and_serial(
-            central_conn, serial_number
-        )
-        path = f"{MONITOR_TYPE}/{serial_number}/lan-tunnels-health-summary"
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}/current-routes"
         return execute_get(central_conn, endpoint=path, version=API_VERSION)
 
-    def _validate_central_conn_and_serial(central_conn, serial_number):
-        """
-        Validate central_conn and serial_number.
 
-        Args:
-            central_conn: Central connection object (required).
-            serial_number (str): Device serial number (required).
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-
-        Note:
-            Internal SDK function
-        """
-        if central_conn is None:
-            raise ParameterError("central_conn is required")
-        # Optionally, check for expected type of central_conn here if needed
-        if not isinstance(serial_number, str) or not serial_number:
-            raise ParameterError(
-                "serial_number is required and must be a string"
-            )

--- a/pycentral/new_monitoring/switches.py
+++ b/pycentral/new_monitoring/switches.py
@@ -1,0 +1,535 @@
+from ..utils.monitoring_utils import (
+    execute_get,
+    generate_timestamp_str,
+    validate_central_conn_and_serial,
+    clean_switch_trend_data,
+)
+from ..exceptions import ParameterError
+
+SWITCH_LIMIT = 1000
+# Maximum length for query parameters (filter_str, sort, search) used across methods
+MAX_QUERY_LEN = 256
+MONITOR_TYPE = "switches"
+
+
+class MonitoringSwitches:
+    @staticmethod
+    def get_all_switches(central_conn, filter_str=None, sort=None):
+        """
+        Retrieve all switches, handling pagination.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
+                See get_switches() for supported fields and operators.
+            sort (str, optional): Optional sort parameter. See get_switches() for supported fields.
+
+        Returns:
+            (list[dict]): List of switch items.
+        """
+        switches = []
+        total_switches = None
+        limit = SWITCH_LIMIT
+        next = 1
+        while True:
+            response = MonitoringSwitches.get_switches(
+                central_conn, filter_str=filter_str, sort=sort, limit=limit, next=next
+            )
+            if total_switches is None:
+                total_switches = response.get("total", 0)
+            switches.extend(response.get("items", []))
+            if len(switches) >= total_switches:
+                break
+            next = response.get("next")
+            if next is None:
+                break
+
+        return switches
+
+    @staticmethod
+    def get_switches(
+        central_conn, filter_str=None, sort=None, limit=SWITCH_LIMIT, next=1
+    ):
+        """
+        Retrieve a single page of switches associated to a customer, based on the query parameters provided.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): OData Version 4.0 filter string (limited functionality). Supports only
+                'and' conjunction ('or' and 'not' are NOT supported). Max length 256.
+                Supported fields and operators:
+                - siteId (eq, in), siteName (eq, in), model (eq, in), status (eq, in), deployment (eq, in).
+            sort (str, optional): Comma separated list of sort expressions. Each expression is a field name
+                optionally followed by 'asc' or 'desc'. Max length 256.
+                Supported fields: siteId, model, status, deployment, serialNumber, deviceName.
+            limit (int, optional): Maximum number of switches to return (0-1000, default is 1000).
+            next (int, optional): Pagination cursor for next page of resources (default is 1).
+
+        Returns:
+            (dict): API response containing keys like 'items', 'total', and 'next'.
+
+        Raises:
+            ParameterError: If limit exceeds 1000.
+            ParameterError: If filter_str exceeds the maximum query length.
+            ParameterError: If sort exceeds the maximum query length.
+        """
+        if limit > SWITCH_LIMIT:
+            raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
+        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
+            )
+        if sort is not None and len(sort) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"sort cannot exceed {MAX_QUERY_LEN} characters"
+            )
+
+        params = {
+            "limit": limit,
+            "next": next,
+            "filter": filter_str,
+            "sort": sort,
+        }
+
+        path = MONITOR_TYPE
+        return execute_get(central_conn, endpoint=path, params=params)
+
+    @staticmethod
+    def get_switch_details(central_conn, serial_number):
+        """
+        Get details for a specific switch by serial number or stack ID.
+
+        In the case of stacked switches, logical switch details and trend data are also provided.
+        The conductor serial may be used instead of a stack ID. Member-level information can be
+        obtained using the listStackMember API.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+
+        Returns:
+            (dict): API response with switch details.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}"
+        return execute_get(central_conn, endpoint=path)
+
+    @staticmethod
+    def get_stack_members(central_conn, serial_number):
+        """
+        Get stack member details for a given stack ID or conductor serial.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Stack ID or conductor serial number.
+
+        Returns:
+            (dict): API response with stack member details.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"stack/{serial_number}/members"
+        return execute_get(central_conn, endpoint=path)
+
+    @staticmethod
+    def get_switch_hardware_categories(central_conn, serial_number):
+        """
+        Get hardware details for a specific switch by serial number or stack ID.
+
+        Conductor serial may also be used instead of a stack ID.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+
+        Returns:
+            (dict): API response with detailed hardware information.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}/hardware-categories"
+        return execute_get(central_conn, endpoint=path)
+
+    @staticmethod
+    def get_switch_lag(central_conn, serial_number):
+        """
+        Get link aggregation group (LAG) summary details for a specific switch by serial number or stack ID.
+
+        Conductor serial may also be used instead of a stack ID.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+
+        Returns:
+            (dict): API response with LAG summary details.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}/lag"
+        return execute_get(central_conn, endpoint=path)
+
+    @staticmethod
+    def get_switch_interfaces(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        search=None,
+        sort=None,
+        limit=SWITCH_LIMIT,
+        offset=0,
+    ):
+        """
+        Get interface details for a specific switch by serial number or stack ID.
+
+        Conductor serial may also be used instead of a stack ID.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+            filter_str (str, optional): OData Version 4.0 filter string (limited functionality). Supports only
+                'and' conjunction ('or' and 'not' are NOT supported). Max length 256.
+                Supported fields and operators:
+                - name, speed, status, connector, duplex, lag, vlanmode, neighbourFamily,
+                  neighbourFunction, poeClass, poeStatus, operStatus (eq, in).
+            search (str, optional): Partial or full string free text search. Max length 256.
+            sort (str, optional): Comma separated list of sort expressions. Each expression is a field name
+                optionally followed by 'asc' or 'desc'. Max length 256. Default sort by name.
+                Supported fields: port, speed, neighbour, neighbourFamily, nativeVlan, neighbourRole,
+                alias, connector, lag, vlanMode, poeClass, ipv4, mtu.
+            limit (int, optional): Number of interfaces to return (0-1000, default is 1000).
+            offset (int, optional): Number of interfaces to skip (default is 0).
+
+        Returns:
+            (dict): API response with a list of interfaces.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+            ParameterError: If limit exceeds 1000.
+            ParameterError: If filter_str, search, or sort exceed the maximum query length.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        if limit > SWITCH_LIMIT:
+            raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
+        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
+            )
+        if search is not None and len(search) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"search cannot exceed {MAX_QUERY_LEN} characters"
+            )
+        if sort is not None and len(sort) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"sort cannot exceed {MAX_QUERY_LEN} characters"
+            )
+
+        params = {
+            "limit": limit,
+            "offset": offset,
+            "filter": filter_str,
+            "search": search,
+            "sort": sort,
+        }
+        path = f"{MONITOR_TYPE}/{serial_number}/interfaces"
+        return execute_get(central_conn, endpoint=path, params=params)
+
+    @staticmethod
+    def get_switch_vlans(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        search=None,
+        sort=None,
+        limit=SWITCH_LIMIT,
+        offset=0,
+    ):
+        """
+        Get VLAN details for a specific switch by serial number or stack ID.
+
+        Conductor serial may also be used instead of a stack ID.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+            filter_str (str, optional): OData Version 4.0 filter string (limited functionality). Supports only
+                'and' conjunction ('or' and 'not' are NOT supported). Max length 256.
+                Supported fields and operators:
+                - status, voice, type (eq, in).
+            search (str, optional): Partial or full string free text search. Max length 256.
+            sort (str, optional): Comma separated list of sort expressions. Each expression is a field name
+                optionally followed by 'asc' or 'desc'. Max length 256. Default sort by id.
+                Supported fields: name, id, status, type, ipv4.
+            limit (int, optional): Number of VLANs to return (0-1000, default is 1000).
+            offset (int, optional): Number of VLANs to skip (default is 0).
+
+        Returns:
+            (dict): API response with a list of VLANs.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+            ParameterError: If limit exceeds 1000.
+            ParameterError: If filter_str, search, or sort exceed the maximum query length.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        if limit > SWITCH_LIMIT:
+            raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
+        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
+            )
+        if search is not None and len(search) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"search cannot exceed {MAX_QUERY_LEN} characters"
+            )
+        if sort is not None and len(sort) > MAX_QUERY_LEN:
+            raise ParameterError(
+                f"sort cannot exceed {MAX_QUERY_LEN} characters"
+            )
+
+        params = {
+            "limit": limit,
+            "offset": offset,
+            "filter": filter_str,
+            "search": search,
+            "sort": sort,
+        }
+        path = f"{MONITOR_TYPE}/{serial_number}/vlans"
+        return execute_get(central_conn, endpoint=path, params=params)
+
+    @staticmethod
+    def get_topn_interface_trends(
+        central_conn,
+        site_id=None,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        return_raw_response=False,
+    ):
+        """
+        Get top-N switch interface trends (rx bytes, tx bytes) for a site over a given time period.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            site_id (str, optional): ID of the site for which switch-related information is requested.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string (e.g. '3h') or seconds for relative queries.
+            return_raw_response (bool, optional): If True, return raw API response; otherwise return
+                processed and sorted trend data. Default is False.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns raw API response; otherwise returns
+                merged, sorted trend statistics.
+
+        Raises:
+            ParameterError: If central_conn is None.
+            ParameterError: If start_time/end_time/duration arguments are invalid.
+        """
+        if not central_conn:
+            raise ParameterError("central_conn is required")
+
+        filter_str = None
+        if start_time is not None or end_time is not None or duration is not None:
+            try:
+                filter_str = generate_timestamp_str(
+                    start_time=start_time, end_time=end_time, duration=duration
+                )
+            except ValueError as e:
+                raise ParameterError(str(e)) from e
+
+        params = {
+            "site-id": site_id,
+            "filter": filter_str,
+        }
+        path = f"{MONITOR_TYPE}/topn-interface-trends"
+        response = execute_get(central_conn, endpoint=path, params=params)
+
+        if return_raw_response:
+            return response
+
+        return clean_switch_trend_data(response)
+
+    @staticmethod
+    def get_switch_interface_trends(
+        central_conn,
+        serial_number,
+        site_id=None,
+        interface_id=None,
+        uplink=None,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        return_raw_response=False,
+    ):
+        """
+        Get interface trend data for a specific switch by serial number or stack ID.
+
+        When a stack ID or conductor serial is provided, trends are aggregated across the entire stack.
+        When a member serial is provided, trends are aggregated for that specific member.
+        Supported metrics include RX bytes, TX bytes, discards, giants, errors, runts, and collisions.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+            site_id (str, optional): ID of the site for which switch-related information is requested.
+            interface_id (str, optional): Interface name of the switch.
+            uplink (bool, optional): Filter by uplink status of the interface.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string (e.g. '3h') or seconds for relative queries.
+            return_raw_response (bool, optional): If True, return raw API response; otherwise return
+                processed and sorted trend data. Default is False.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns raw API response; otherwise returns
+                merged, sorted trend data.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+            ParameterError: If start_time/end_time/duration arguments are invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+
+        filter_str = None
+        if start_time is not None or end_time is not None or duration is not None:
+            try:
+                filter_str = generate_timestamp_str(
+                    start_time=start_time, end_time=end_time, duration=duration
+                )
+            except ValueError as e:
+                raise ParameterError(str(e)) from e
+
+        params = {
+            "site-id": site_id,
+            "interface-id": interface_id,
+            "uplink": uplink,
+            "filter": filter_str,
+        }
+        path = f"{MONITOR_TYPE}/{serial_number}/interface-trends"
+        response = execute_get(central_conn, endpoint=path, params=params)
+
+        if return_raw_response:
+            return response
+
+        return clean_switch_trend_data(response)
+
+    @staticmethod
+    def get_switch_hardware_trends(
+        central_conn,
+        serial_number,
+        site_id=None,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        return_raw_response=False,
+    ):
+        """
+        Get hardware trend data for a specific switch by serial number or stack ID.
+
+        When a stack ID or conductor serial is provided, trends are aggregated for each member of the stack.
+        When a member serial is provided, trends are aggregated for that specific member.
+        Available metrics include CPU utilization, memory utilization, PoE available, PoE consumption,
+        and total power available. By default, data is aggregated over the last three hours.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+            site_id (str, optional): ID of the site for which switch-related information is requested.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string (e.g. '3h') or seconds for relative queries.
+            return_raw_response (bool, optional): If True, return raw API response; otherwise return
+                processed and sorted trend data. Default is False.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns raw API response; otherwise returns
+                merged, sorted trend data.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+            ParameterError: If start_time/end_time/duration arguments are invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+
+        filter_str = None
+        if start_time is not None or end_time is not None or duration is not None:
+            try:
+                filter_str = generate_timestamp_str(
+                    start_time=start_time, end_time=end_time, duration=duration
+                )
+            except ValueError as e:
+                raise ParameterError(str(e)) from e
+
+        params = {
+            "site-id": site_id,
+            "filter": filter_str,
+        }
+        path = f"{MONITOR_TYPE}/{serial_number}/hardware-trends"
+        response = execute_get(central_conn, endpoint=path, params=params)
+
+        if return_raw_response:
+            return response
+
+        return clean_switch_trend_data(response)
+
+    @staticmethod
+    def get_switch_interface_poe(central_conn, serial_number):
+        """
+        Get interface PoE details for a specific switch by serial number or stack ID.
+
+        Conductor serial may also be used instead of a stack ID.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch (standalone), stack ID, or conductor
+                serial (stacked).
+
+        Returns:
+            (dict): API response with interface PoE details.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}/interface-poe"
+        return execute_get(central_conn, endpoint=path)
+
+    @staticmethod
+    def get_switch_vsx(central_conn, serial_number):
+        """
+        Get Virtual Switching Extension (VSX) details for a specific switch.
+
+        Returns VSX configuration and operational details for the specified switch. If the switch
+        does not support VSX or VSX is not configured, the API returns a 200 response with an
+        empty VSX object (all fields null).
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the switch.
+
+        Returns:
+            (dict): API response with VSX configuration and operational details.
+
+        Raises:
+            ParameterError: If central_conn is None or serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        path = f"{MONITOR_TYPE}/{serial_number}/vsx"
+        return execute_get(central_conn, endpoint=path)

--- a/pycentral/scopes/device.py
+++ b/pycentral/scopes/device.py
@@ -736,7 +736,7 @@ class Device(ScopeBase):
 
         Args:
             **kwargs (dict, Optional): Arguments for event listing. See [Troubleshooting.list_events()](troubleshooting.md#pycentral.troubleshooting.troubleshooting.Troubleshooting.list_events) for all parameters.
-                Required parameters: start_at, end_at, site_id
+                Required parameters: site_id and either duration or both start_at and end_at
 
         Returns:
             (dict): Response containing events list, count, total, and pagination cursor
@@ -744,6 +744,27 @@ class Device(ScopeBase):
         self._ensure_materialized()
 
         return Troubleshooting.list_events(
+            central_conn=self.central_conn,
+            context_type=self.device_type,
+            context_id=self.serial,
+            **kwargs,
+        )
+
+    def list_event_filters(self, **kwargs):
+        """Retrieves available event filter options for this device.
+
+        Supported device types: All (aps, cx, aos-s, gateways)
+
+        Args:
+            **kwargs (dict, Optional): Arguments for event filter listing. See [Troubleshooting.list_event_filters()](troubleshooting.md#pycentral.troubleshooting.troubleshooting.Troubleshooting.list_event_filters) for all parameters.
+                Required parameters: site_id and either duration or both start_at and end_at
+
+        Returns:
+            (dict): Response containing available event filter options
+        """
+        self._ensure_materialized()
+
+        return Troubleshooting.list_event_filters(
             central_conn=self.central_conn,
             context_type=self.device_type,
             context_id=self.serial,

--- a/pycentral/scopes/site.py
+++ b/pycentral/scopes/site.py
@@ -12,6 +12,7 @@ from ..utils.scope_utils import (
     set_attributes,
     get_scope_element,
     rename_keys,
+    validate_iso_location,
 )
 
 scope_maps = ScopeMaps()
@@ -338,6 +339,11 @@ class Site(ScopeBase):
         Returns:
             (dict): Dictionary of site attributes needed for making API calls to Central
         """
+        # Validate location attributes follow ISO 3166 before building API body
+        validate_iso_location(
+            country=self.country, state=self.state, city=self.city
+        )
+
         api_body = {
             "name": self.get_name(),
             "address": self.address,

--- a/pycentral/troubleshooting/troubleshooting.py
+++ b/pycentral/troubleshooting/troubleshooting.py
@@ -1,6 +1,7 @@
 from ..utils.url_utils import generate_url
 import time
 from ..exceptions import ParameterError
+from ..utils.monitoring_utils import build_timestamp_filter
 from ..utils.troubleshooting_utils import (
     SUPPORTED_DEVICE_TYPES,
     TROUBLESHOOTING_METHOD_DEVICE_MAPPING,
@@ -4781,9 +4782,10 @@ class Troubleshooting:
         central_conn,
         context_type,
         context_id,
-        start_at,
-        end_at,
         site_id,
+        start_at=None,
+        end_at=None,
+        duration=None,
         search=None,
         filter_str=None,
         sort=None,
@@ -4802,14 +4804,18 @@ class Troubleshooting:
                 'GATEWAY', 'WIRELESS_CLIENT', 'WIRED_CLIENT', or 'BRIDGE').
             context_id (str): Context Id (site id, device serial number or client
                 mac address). Max length 128.
-            start_at (str): Data is required starting from this timestamp, provided
-                in RFC 3339 (and ISO 8601) format in the UTC+0 timezone. The difference
-                between end_at and start_at should be less than 30 days. Max length 30.
-            end_at (str): Data is required up to this timestamp, provided in RFC 3339
-                (and ISO 8601) format in the UTC+0 timezone. Must be earlier than the
-                current time and later than start_at. Max length 30.
             site_id (str): Site ID to filter the event details for a specific site.
                 Max length 128.
+            start_at (str, optional): Data is required starting from this timestamp,
+                provided in RFC 3339 (and ISO 8601) format in the UTC+0 timezone.
+                Must be provided together with end_at when duration is not used.
+                The difference between end_at and start_at must not exceed 30 days.
+            end_at (str, optional): Data is required up to this timestamp, provided
+                in RFC 3339 (and ISO 8601) format in the UTC+0 timezone. Must be
+                provided together with start_at when duration is not used.
+            duration (str, optional): Relative event window such as '3h', '2d',
+                '1w', or '30m'. Provide either duration or both start_at and end_at,
+                but not both. Maximum supported duration is 30 days.
             search (str, optional): Search events by name, serial number, host name,
                 client mac address or device mac address. Full text search is not
                 supported. Search is restricted to meta-data. Max length 256.
@@ -4838,12 +4844,12 @@ class Troubleshooting:
         Raises:
             ParameterError: If context_type is not a valid value.
             ParameterError: If context_id exceeds 128 characters.
-            ParameterError: If start_at or end_at are not valid strings.
+            ParameterError: If the time window parameters are invalid.
             ParameterError: If site_id exceeds 128 characters.
             ParameterError: If search exceeds 256 characters.
             ParameterError: If filter_str exceeds 512 characters.
             ParameterError: If sort exceeds 128 characters.
-            ParameterError: If next_cursor is less than 1.
+            ParameterError: If next_cursor is not an integer/string >= 1.
             ParameterError: If limit is not between 1 and 1000.
             Exception: If retrieving the events fails.
         """
@@ -4868,20 +4874,21 @@ class Troubleshooting:
         elif len(context_id) > 128:
             raise ParameterError("context_id must not exceed 128 characters")
 
-        if not start_at or not isinstance(start_at, str):
-            raise ParameterError(
-                "start_at must be a valid RFC 3339 timestamp string"
-            )
-
-        if not end_at or not isinstance(end_at, str):
-            raise ParameterError(
-                "end_at must be a valid RFC 3339 timestamp string"
-            )
-
         if not site_id or not isinstance(site_id, str):
             raise ParameterError("site_id must be a non-empty string")
         elif len(site_id) > 128:
             raise ParameterError("site_id must not exceed 128 characters")
+
+        try:
+            start_at, end_at = build_timestamp_filter(
+                start_time=start_at,
+                end_time=end_at,
+                duration=duration,
+                fmt="rfc3339",
+                max_period_days=30,
+            )
+        except ValueError as e:
+            raise ParameterError(str(e)) from e
 
         # Validate optional parameters
         if search is not None:
@@ -4904,8 +4911,16 @@ class Troubleshooting:
             elif len(sort) > 128:
                 raise ParameterError("sort must not exceed 128 characters")
 
-        if not isinstance(next_cursor, int) or next_cursor < 1:
-            raise ParameterError("next_cursor must be an integer >= 1")
+        if not isinstance(next_cursor, (int, str)):
+            raise ParameterError("next_cursor must be an integer or string")
+        if isinstance(next_cursor, int) and next_cursor < 1:
+            raise ParameterError("next_cursor must be >= 1")
+        if isinstance(next_cursor, str):
+            try:
+                if int(next_cursor) < 1:
+                    raise ParameterError("next_cursor must be >= 1")
+            except ValueError:
+                raise ParameterError("next_cursor must be a numeric string")
 
         if not isinstance(limit, int) or not (1 <= limit <= 1000):
             raise ParameterError("limit must be an integer between 1 and 1000")
@@ -4913,7 +4928,7 @@ class Troubleshooting:
         # Build query parameters
         params = {
             "context-type": context_type,
-            "context-id": context_id,
+            "context-identifier": context_id,
             "start-at": start_at,
             "end-at": end_at,
             "site-id": site_id,
@@ -4943,6 +4958,190 @@ class Troubleshooting:
         central_conn.logger.info(
             f"Successfully retrieved {resp['msg'].get('count', 0)} events "
             f"for context {context_type} {context_id}"
+        )
+
+        return resp["msg"]
+
+    @staticmethod
+    def list_event_filters(
+        central_conn,
+        context_type,
+        context_id,
+        site_id,
+        start_at=None,
+        end_at=None,
+        duration=None,
+    ):
+        """Retrieves available filter options for network events.
+
+        Returns categories, source types, and event names with their
+        respective counts. Use this information to construct filters for
+        the list_events API.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            context_type (str): Type of context ('SITE', 'ACCESS_POINT', 'SWITCH',
+                'GATEWAY', 'WIRELESS_CLIENT', 'WIRED_CLIENT', or 'BRIDGE').
+            context_id (str): Context identifier (site ID, device serial number
+                or client MAC address). Max length 128.
+            site_id (str): Site ID to filter the event details for a specific site.
+                Max length 128.
+            start_at (str, optional): Data is required starting from this timestamp,
+                provided in RFC 3339 (and ISO 8601) format in the UTC+0 timezone.
+                Must be provided together with end_at when duration is not used.
+                The difference between end_at and start_at must not exceed 30 days.
+            end_at (str, optional): Data is required up to this timestamp, provided
+                in RFC 3339 (and ISO 8601) format in the UTC+0 timezone. Must be
+                provided together with start_at when duration is not used.
+            duration (str, optional): Relative event window such as '3h', '2d',
+                '1w', or '30m'. Provide either duration or both start_at and end_at,
+                but not both. Maximum supported duration is 30 days.
+
+
+        Returns:
+            (dict): Response containing available filter options including
+                categories, source types, and event names with counts.
+
+        Raises:
+            ParameterError: If context_type is not a valid value.
+            ParameterError: If context_id exceeds 128 characters.
+            ParameterError: If the time window parameters are invalid.
+            ParameterError: If site_id exceeds 128 characters.
+            Exception: If retrieving the event filters fails.
+        """
+        valid_context_types = [
+            "SITE",
+            "ACCESS_POINT",
+            "SWITCH",
+            "GATEWAY",
+            "WIRELESS_CLIENT",
+            "WIRED_CLIENT",
+            "BRIDGE",
+        ]
+
+        if not context_type or context_type not in valid_context_types:
+            raise ParameterError(
+                f"context_type must be one of {', '.join(valid_context_types)}"
+            )
+
+        if not context_id or not isinstance(context_id, str):
+            raise ParameterError("context_id must be a non-empty string")
+        elif len(context_id) > 128:
+            raise ParameterError("context_id must not exceed 128 characters")
+
+        if not site_id or not isinstance(site_id, str):
+            raise ParameterError("site_id must be a non-empty string")
+        elif len(site_id) > 128:
+            raise ParameterError("site_id must not exceed 128 characters")
+
+        try:
+            start_at, end_at = build_timestamp_filter(
+                start_time=start_at,
+                end_time=end_at,
+                duration=duration,
+                fmt="rfc3339",
+                max_period_days=30,
+            )
+        except ValueError as e:
+            raise ParameterError(str(e)) from e
+
+        params = {
+            "context-type": context_type,
+            "context-identifier": context_id,
+            "start-at": start_at,
+            "end-at": end_at,
+            "site-id": site_id,
+        }
+
+        api_path = generate_url("event-filters", "troubleshooting")
+        resp = central_conn.command(
+            api_method="GET", api_path=api_path, api_params=params
+        )
+
+        if resp["code"] != 200:
+            raise Exception(
+                f"Failed to list event filters: {resp['code']} - {resp['msg']}"
+            )
+
+        central_conn.logger.info(
+            f"Successfully retrieved event filters for context "
+            f"{context_type} {context_id}"
+        )
+
+        return resp["msg"]
+
+    @staticmethod
+    def get_event_extra_attributes(
+        central_conn,
+        event_identifier,
+        site_id,
+        time_at,
+    ):
+        """Retrieves extra attributes of an event.
+
+        The response includes event attributes as key-value pairs providing
+        additional detail beyond what is returned in the list_events response.
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            event_identifier (str): Unique identifier of the event to retrieve
+                details for. Max length 128.
+            site_id (str): Site ID to filter the event details for a specific site.
+                Max length 128.
+            time_at (str): Timestamp of when the event occurred, provided in
+                RFC 3339 (and ISO 8601) format in the UTC+0 timezone with
+                milliseconds. Max length 30.
+
+        Returns:
+            (dict): Response containing event extra attributes as key-value pairs.
+
+        Raises:
+            ParameterError: If event_identifier exceeds 128 characters.
+            ParameterError: If site_id exceeds 128 characters.
+            ParameterError: If time_at is not a valid string.
+            Exception: If retrieving the event extra attributes fails.
+        """
+        if not event_identifier or not isinstance(event_identifier, str):
+            raise ParameterError(
+                "event_identifier must be a non-empty string"
+            )
+        elif len(event_identifier) > 128:
+            raise ParameterError(
+                "event_identifier must not exceed 128 characters"
+            )
+
+        if not site_id or not isinstance(site_id, str):
+            raise ParameterError("site_id must be a non-empty string")
+        elif len(site_id) > 128:
+            raise ParameterError("site_id must not exceed 128 characters")
+
+        if not time_at or not isinstance(time_at, str):
+            raise ParameterError(
+                "time_at must be a valid RFC 3339 timestamp string"
+            )
+
+        params = {
+            "event-identifier": event_identifier,
+            "site-id": site_id,
+            "time-at": time_at,
+        }
+
+        api_path = generate_url(
+            "event-extra-attributes", "troubleshooting"
+        )
+        resp = central_conn.command(
+            api_method="GET", api_path=api_path, api_params=params
+        )
+
+        if resp["code"] != 200:
+            raise Exception(
+                f"Failed to get event extra attributes: {resp['code']} "
+                f"- {resp['msg']}"
+            )
+
+        central_conn.logger.info(
+            f"Successfully retrieved extra attributes for event "
+            f"{event_identifier}"
         )
 
         return resp["msg"]

--- a/pycentral/utils/monitoring_utils.py
+++ b/pycentral/utils/monitoring_utils.py
@@ -189,6 +189,75 @@ def _groups_to_dict(groups_list):
     return result
 
 
+def clean_switch_trend_data(raw_response):
+    """Process switch trend responses into a normalized list.
+
+    Handles all formats returned by the switch trend endpoints:
+    - Top-N interface trends: ``response.items``
+    - Hardware trends: ``response.switchMetrics[].samples`` with top-level ``keys``
+    - Interface trends: ``response.samples`` with top-level ``keys``
+
+    Timestamps are converted from epoch milliseconds to RFC3339 (UTC).
+
+    Args:
+        raw_response (dict): Raw response from ``execute_get`` for a switch trend endpoint.
+
+    Returns:
+        (list[dict]):
+            - Top-N endpoint: ``response.items`` list as-is.
+            - Hardware/interface trends: sorted list of dicts with ``timestamp`` and one
+              key per metric. Hardware trends for stacked switches also include
+              ``serialNumber``.
+    """
+    inner = raw_response.get("response", {}) if isinstance(raw_response, dict) else {}
+
+    # Top-N interface trends: response.items
+    if isinstance(inner, dict):
+        items = inner.get("items")
+        if isinstance(items, list):
+            return items
+
+    keys = inner.get("keys", [])
+    rows = []
+
+    # Hardware trends: switchMetrics[].samples
+    for switch_metric in inner.get("switchMetrics", []):
+        serial = switch_metric.get("serialNumber")
+        for sample in switch_metric.get("samples", []):
+            ts_ms = sample.get("timestamp")
+            data = sample.get("data")
+            if ts_ms is None or not data:
+                continue
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            row = {"timestamp": ts}
+            if serial:
+                row["serialNumber"] = serial
+            for k, v in zip(keys, data):
+                if v is not None:
+                    row[k] = v
+            rows.append(row)
+
+    # Interface trends: samples directly at response level
+    if not rows:
+        for sample in inner.get("samples", []):
+            ts_ms = sample.get("timestamp")
+            data = sample.get("data")
+            if ts_ms is None or not data:
+                continue
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            row = {"timestamp": ts}
+            for k, v in zip(keys, data):
+                if v is not None:
+                    row[k] = v
+            rows.append(row)
+
+    return sorted(rows, key=lambda r: r["timestamp"])
+
+
 def clean_raw_trend_data(raw_results, data=None):
     """Clean and restructure raw trend data from API response.
 
@@ -268,3 +337,44 @@ def _validate_mac_address(mac):
             f"Invalid MAC address format: '{mac}'. Expected format: AA:BB:CC:DD:EE:FF"
         )
     return True
+
+
+def validate_device_serial(serial_number):
+    """
+    Validate device serial number.
+
+    Args:
+        serial_number (str): Device serial number to validate.
+
+    Raises:
+        ParameterError: If serial_number is missing or not a string.
+
+    Note:
+        Internal SDK function
+    """
+    if not isinstance(serial_number, str) or not serial_number:
+        raise ParameterError(
+            "serial_number is required and must be a string"
+        )
+
+
+def validate_central_conn_and_serial(central_conn, serial_number):
+    """
+    Validate central connection and device serial number.
+
+    Args:
+        central_conn (NewCentralBase): Central connection object (required).
+        serial_number (str): Device serial number (required).
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+
+    Note:
+        Internal SDK function
+    """
+    if central_conn is None:
+        raise ParameterError("central_conn is required")
+    if not isinstance(serial_number, str) or not serial_number:
+        raise ParameterError(
+            "serial_number is required and must be a string"
+        )

--- a/pycentral/utils/monitoring_utils.py
+++ b/pycentral/utils/monitoring_utils.py
@@ -6,11 +6,15 @@ from ..exceptions import ParameterError
 import re
 
 
+DEFAULT_MAX_PERIOD_DAYS = 90
+
+
 def build_timestamp_filter(
     start_time=None,
     end_time=None,
     duration=None,
     fmt="rfc3339",
+    max_period_days=DEFAULT_MAX_PERIOD_DAYS,
 ):
     """Build a formatted timestamp filter for API queries.
 
@@ -20,7 +24,7 @@ def build_timestamp_filter(
         - If start_time and end_time are given, parses and converts them to the
           requested format.
         - If duration is given, computes timestamps relative to now.
-        - Max supported duration is 3 months (90 days).
+                - Max supported duration defaults to 90 days and can be overridden.
 
     Args:
         start_time (str, optional): RFC3339 or Unix timestamp (ms or s) for start.
@@ -28,12 +32,15 @@ def build_timestamp_filter(
         duration (str, optional): Duration string like '3h', '2d', '1w', '1m'
             (hours, days, weeks, minutes).
         fmt (str, optional): Output format, either 'rfc3339' or 'unix'.
+        max_period_days (int|float, optional): Maximum allowed duration, in days.
+            Defaults to DEFAULT_MAX_PERIOD_DAYS.
 
     Returns:
         (tuple): A tuple of (start_time, end_time) formatted strings.
 
     Raises:
-        ValueError: If invalid parameter combinations are provided or duration exceeds maximum.
+        ValueError: If invalid parameter combinations are provided, the maximum
+            duration is invalid, or duration exceeds the configured maximum.
     """
     # --- Validation ---
     if (start_time or end_time) and duration:
@@ -42,6 +49,8 @@ def build_timestamp_filter(
         raise ValueError("Both start_time and end_time must be provided together.")
     if not duration and not (start_time and end_time):
         raise ValueError("Provide either both start_time and end_time or a duration.")
+    if max_period_days is None or max_period_days <= 0:
+        raise ValueError("max_period_days must be greater than 0.")
 
     # --- Case 1: Start + End ---
     if start_time and end_time:
@@ -59,8 +68,10 @@ def build_timestamp_filter(
         )
 
     delta = timedelta(**{unit_map[unit]: int(duration[:-1])})
-    if delta > timedelta(days=90):
-        raise ValueError("Maximum supported duration is 3 months (90 days).")
+    if delta > timedelta(days=max_period_days):
+        raise ValueError(
+            f"Maximum supported duration is {max_period_days} days."
+        )
 
     now = datetime.now(timezone.utc)
     return _format_timestamp(now - delta, fmt), _format_timestamp(now, fmt)
@@ -86,19 +97,25 @@ def _format_timestamp(dt, fmt):
     return dt.isoformat().replace("+00:00", "Z")
 
 
-def generate_timestamp_str(start_time, end_time, duration):
+def generate_timestamp_str(
+    start_time, end_time, duration, max_period_days=DEFAULT_MAX_PERIOD_DAYS
+):
     """Generate a timestamp filter string for API queries.
 
     Args:
         start_time (str): Start timestamp.
         end_time (str): End timestamp.
         duration (str): Duration string.
+        max_period_days (int|float, optional): Maximum allowed duration, in days.
 
     Returns:
         (str): Formatted filter string "timestamp gt <start> and timestamp lt <end>".
     """
     start_time, end_time = build_timestamp_filter(
-        start_time=start_time, end_time=end_time, duration=duration
+        start_time=start_time,
+        end_time=end_time,
+        duration=duration,
+        max_period_days=max_period_days,
     )
     return f"timestamp gt {start_time} and timestamp lt {end_time}"
 

--- a/pycentral/utils/scope_utils.py
+++ b/pycentral/utils/scope_utils.py
@@ -4,6 +4,7 @@
 from ..scopes.scope_maps import ScopeMaps
 from pycentral.utils import SCOPE_URLS, generate_url
 import copy
+import pycountry
 
 scope_maps = ScopeMaps()
 
@@ -277,6 +278,49 @@ def validate_find_scope_elements(ids=None, names=None, serials=None, scope=""):
         raise ValueError(
             "Serials can only be used with the 'device' scope or when no scope is provided."
         )
+
+
+def validate_iso_location(state=None, country=None, city=None):
+    """Validate the input parameters for ISO 3166-1 short name format for location.
+
+    Args:
+        state (str, optional): State name, i.e., "California".
+        country (str, optional): Country name, i.e., "United States".
+        city (str, optional): City name, i.e., "San Francisco".
+
+    Raises:
+        ValueError: If validation fails invalid values.
+    """
+    # Ensure that at least one of state, country, or city is provided and they're all strings if provided
+    if not any([state, country, city]) or not all(
+        isinstance(param, str)
+        for param in [state, country, city]
+        if param is not None
+    ):
+        raise ValueError(
+            "At least one of 'state', 'country', or 'city' must be provided and all must be strings if provided"
+        )
+
+    # Validate Country using pycountry
+    if country:
+        try:
+            pycountry.countries.lookup(country)
+        except LookupError:
+            raise ValueError(
+                f"Invalid country name: {country} Must be in ISO 3166 short name format, e.g., 'United States'"
+            )
+    # Validate State using pycountry
+    if state:
+        try:
+            pycountry.subdivisions.lookup(state)
+        except LookupError:
+            raise ValueError(
+                f"Invalid state name: {state} Must be in ISO 3166 short name format, e.g., 'California'"
+            )
+
+    # Validate City as a non-empty string if provided
+    if city is not None and not city.strip():
+        raise ValueError("City name must be a non-empty string.")
 
 
 def lookup_in_map(keys, lookup_map):

--- a/pycentral/utils/url_utils.py
+++ b/pycentral/utils/url_utils.py
@@ -17,7 +17,7 @@ CATEGORIES = {
     "troubleshooting": {
         "value": "network-troubleshooting",
         "type": "troubleshooting",
-        "latest": "v1alpha1",
+        "latest": "v1",
     },
     "subscriptions": {"value": "subscriptions", "type": "glp", "latest": "v1"},
     "user_management": {"value": "identity", "type": "glp", "latest": "v1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "protobuf==6.33.5",
     "websocket-client==1.9.0",
     "httpx[http2]==0.28.1",
-    "requests==2.33.0"
+    "requests==2.33.0",
+    "pycountry==26.2.16"
 ]
 [project.optional-dependencies]
 colorLog = ["colorlog"]


### PR DESCRIPTION
This release introduces MSP tenant connection management, a new Switches monitoring module, expanded troubleshooting event capabilities, ISO location validation for site creation, and refactored shared monitoring utilities.

### New Features

- **MSP Tenant Connection Support**
  - Added `MSPBase` class — a `NewCentralBase` subclass for Managed Service Provider workflows
  - `get_tenant_connection(tenant_name, tenant_workspace_id)` performs an RFC 8693 token exchange and returns an isolated `TenantBase` connection scoped to a specific tenant's Central environment
  - Tenant connections are cached internally; repeat calls with the same `tenant_workspace_id` return the same `TenantBase` instance without re-running the exchange
  - `close_tenant_connection(tenant_workspace_id)` closes a single cached tenant connection
  - `get_tenant_id(tenant_name)` resolves a tenant display name to its GLP workspace ID
  - Added `TenantBase` class that overrides `_renew_token()` to re-exchange the MSP parent token automatically when a tenant-scoped token expires
- **Switches Monitoring Module**
  - Added `MonitoringSwitches` class with the following methods:
    - `get_all_switches`, `get_switches` — paginated switch retrieval with filter and sort support
    - `get_switch_details` — fetch details for a specific switch by serial number
    - `get_stack_members` — retrieve stack members for a stacked switch
    - `get_switch_hardware_categories` — hardware category data for a switch
    - `get_switch_lag` — LAG (Link Aggregation Group) information
    - `get_switch_interfaces` — interface list with optional filtering and pagination
    - `get_switch_vlans` — VLAN membership data for a switch
    - `get_topn_interface_trends` — top-N interface utilization trends
    - `get_switch_interface_trends` — per-interface trend data over a time range
    - `get_switch_hardware_trends` — hardware utilization trends (CPU, memory, etc.)
    - `get_switch_interface_poe` — PoE usage data per interface
    - `get_switch_vsx` — VSX (Virtual Switching Extension) state for a switch
- **Troubleshooting Event Enhancements**
  - Added `list_event_filters` method to `Troubleshooting` and `Device` classes to retrieve available event filter options
  - Added `get_event_extra_attributes` method to fetch additional metadata fields for a specific event type
  - `list_events` now accepts an optional `duration` parameter for time-range based filtering
- **ISO Location Validation for Site Creation**
  - `Site.create_site()` now validates `country`, `state`, and `city` inputs against ISO 3166 standards via the new `validate_iso_location` utility before submitting the API request
  - Added `pycountry` dependency (`26.2.16`) to support ISO validation

### Improvements

- Extracted `validate_device_serial`, `validate_central_conn_and_serial`, `generate_timestamp_str`, and `clean_switch_trend_data` from per-module private helpers into shared `monitoring_utils` so APs, Gateways, and Switches all use the same validation path
- Added `_renew_token()` hook to `NewCentralBase` — subclasses can now override token renewal behavior without patching `command()`
- `LoginError` and `ValueError` are now re-raised directly from `command()` instead of being wrapped in `ResponseError`, making authentication failures easier to catch programmatically
- Improved error message when token creation does not return an `access_token`, providing clearer guidance on verifying client credentials and token URL
- HTTP client close failures are now logged at `ERROR` level instead of `DEBUG`
- Updated Switches monitoring documentation in `docs/modules/new_monitoring.md`
- Added full MSP module documentation in `docs/modules/msp.md`
