### PR TITLE
v2.0a20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > This is a **pre-release version** of PyCentral-v2, and the features are constantly being updated as the APIs evolve. This version of the SDK allows you to make API calls to New Central, GLP, and Classic Central.  
 > If you are looking for the stable version of PyCentral (v1), it is still available and fully supported. PyCentral-v1, which only supports Classic Central, can be found [here](https://pypi.org/project/pycentral/).
 
-A Python SDK for interacting with **HPE Aruba Networking Central** via REST APIs.  
+A Python SDK for interacting with **Central** via REST APIs.  
 Automate onboarding, configuration, monitoring, and management for:
 - **New Central**
 - **HPE GreenLake Platform (GLP)**
@@ -147,5 +147,5 @@ The Classic Central functionality is still fully supported by the SDK and has be
 - <a href="https://pycentral.readthedocs.io/en/v1.4.3/" target="_blank">Python Module documentation</a>
 
 ### **Use-Cases and Workflows**
-- <a href="https://developer.arubanetworks.com/central/docs/python-getting-started" target="_blank">HPE Aruba Networking Developer Hub</a>
+- <a href="https://developer.arubanetworks.com/central/docs/python-getting-started" target="_blank">HPE Networking Developer Hub</a>
 - <a href="https://github.com/aruba/central-python-workflows/tree/main" target="_blank">central-python-workflows</a>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,51 @@
+# 2.0a20
+
+This release significantly expands the monitoring module coverage for APs, Gateways, and WLANs, adds 429 rate-limit retry handling, fixes streaming WebSocket client issues, and updates product branding across the SDK.
+
+### New Features
+
+- **Expanded AP Monitoring Module**
+  - Added fleet-level retrieval methods: `get_all_radios`, `get_radios`, `get_all_bssids`, `get_bssids`, `get_all_swarms`, `get_swarms`, `get_swarm_details`
+  - Added per-AP sub-resource methods: `get_ap_radios`, `get_ap_ports`, `get_all_ap_tunnels`, `get_ap_tunnels`, `get_ap_tunnel_details`, `get_ap_wlans`
+  - Added trend endpoints: `get_ap_trends` (throughput, CPU, memory, power consumption), `get_ap_radio_trends` (throughput, channel utilization/quality, noise floor, frames), `get_ap_port_trends` (throughput, frames, CRC, collisions), `get_ap_tunnel_trends` (throughput, packet loss, MOS, jitter, latency)
+- **Expanded Gateway Monitoring Module**
+  - Added sub-resource methods: `get_all_gateway_ports`, `get_gateway_ports`, `get_gateway_port_details`, `get_all_gateway_vlans`, `get_gateway_vlans`, `get_gateway_vlan_details`, `get_all_gateway_tunnels`, `get_gateway_tunnels`, `get_gateway_tunnel_details`, `get_gateway_uplinks`, `get_gateway_uplink_details`, `get_all_gateway_dhcp_pools`, `get_gateway_dhcp_pools`, `get_all_gateway_dhcp_clients`, `get_gateway_dhcp_clients`
+  - Added trend endpoints: `get_gateway_trends` (CPU, memory, WAN/VPN availability, hardware temperature), `get_gateway_port_trends` (throughput, frames, errors, packets), `get_gateway_tunnel_trends` (throughput, status, dropped packets), `get_gateway_uplink_trends` (throughput, WAN compression, WAN availability)
+  - Added uplink probe methods: `get_gateway_uplink_probes`, `get_gateway_uplink_probe_performance_trends`, `get_gateway_uplink_vpn_availability_trends`
+  - Added tunnel health: `get_gateway_tunnel_health_summary` (LAN/WAN)
+  - Added cluster methods: `get_all_cluster_members`, `get_cluster_members`, `get_all_cluster_tunnels`, `get_cluster_tunnels`, `get_cluster_vlan_mismatch`, `get_cluster_connectivity_graph`, `get_cluster_tunnel_summary`, `get_cluster_capacity_trends`
+- **WLAN Monitoring Module**
+  - Added `WLAN` class with `get_all_wlans` and `get_wlans` methods supporting site_id, serial_number, filter, and sort parameters
+- **429 Rate-Limit Retry**
+  - `NewCentralBase.command()` now retries once after a 1-second pause when a 429 (Too Many Requests) response is received; logs an error and exits if the second attempt also fails
+
+### Bug Fixes
+
+- **Streaming WebSocket Client**
+  - Event-type filters are now sent as URL query parameters instead of custom headers, fixing filter delivery to the server
+  - Token refresh uses internal `_renew_token()` instead of deprecated `handle_expired_token()`
+  - Cached `app_route` and `token_key` for correct internal lookups
+  - Query parameters are stripped from connection log messages for readability
+
+### Improvements
+
+- **Shared Monitoring Utilities**
+  - Added `get_all_pages` — generic pagination helper that replaces per-module while loops
+  - Added `execute_trend_request` and `normalize_trend_response` — unified trend endpoint execution and response normalization
+  - Added validation helpers: `validate_site_id`, `validate_query_length`, `validate_limit_and_next`, `validate_required_value`, `validate_serial_query`, `normalize_metric`, `build_trend_params`
+  - Fixed `execute_get` default params (mutable default argument) and endpoint validation logic
+  - Renamed `clean_switch_trend_data` → `_clean_switch_trend_data` (internal)
+- **Constants Consolidation**
+  - Extracted all pagination limits (AP_LIMIT, GATEWAY_LIMIT, SWITCH_LIMIT, etc.) into `pycentral/new_monitoring/constants.py`
+- **Branding Update**
+  - Shortened "HPE Aruba Networking Central" references to "Central" across documentation, docstrings, and project metadata
+  - Updated project author to `hpe-networking-automation`
+- Switches module refactored to use shared `get_all_pages`, `build_trend_params`, and validation utilities
+- Updated monitoring API reference documentation with endpoint tables for APs, Gateways, and WLANs
+- Fixed `next_cursor` type annotation in troubleshooting docstring (`int` → `int or str`)
+
+Full Changelog: [v2.0a19...v2.0a20](https://github.com/aruba/pycentral/compare/v2.0a19...v2.0a20)
+
 # 2.0a19
 
 This release introduces MSP tenant connection management, a new Switches monitoring module, expanded troubleshooting event capabilities, ISO location validation for site creation, and refactored shared monitoring utilities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # PyCentral Documentation
 
-PyCentral is a Python SDK that makes it easier to interact with HPE Aruba Networking Central and the HPE GreenLake Platform (GLP) through REST APIs. Instead of building and managing low-level HTTP requests, developers can:
+PyCentral is a Python SDK that makes it easier to interact with Central and the HPE GreenLake Platform (GLP) through REST APIs. Instead of building and managing low-level HTTP requests, developers can:
 
 - Authenticate securely
 - Configure and manage devices and subscriptions
@@ -22,12 +22,12 @@ PyCentral(v2) is the latest version of the SDK, designed for compatibility and s
 ## Versions
 
 PyCentral-v2 is currently in pre-release, and we welcome feedback [here](https://github.com/aruba/pycentral/issues) as we continue improving it.
-Today, there are two versions of PyCentral, each designed for different versions of HPE Aruba Networking Central
+Today, there are two versions of PyCentral, each designed for different versions of Central
 
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
-| [v1](https://pypi.org/project/pycentral/)                      | HPE Aruba Networking Central (Classic Central)                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a19/) | HPE Aruba Networking Central(new Central), GLP, HPE Aruba Networking Central (Classic Central) | Backwards compatible with v1 |
+| [v1](https://pypi.org/project/pycentral/)                      | Classic Central                                                 | Legacy Version               |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a10/) | Central( or new Central), GLP, Classic Central | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/docs/modules/new_monitoring.md
+++ b/docs/modules/new_monitoring.md
@@ -92,6 +92,23 @@ Monitoring modules available in the PyCentral SDK are separated by type APs, Cli
 ## Switches
 ::: pycentral.new_monitoring.switches
 
+| Module name | API endpoint(s) | Description |
+| --- | --- | --- |
+| `get_all_switches` | `GET network-monitoring/v1/switches` | Retrieves all switches by paging through the switch listing endpoint. |
+| `get_switches` | `GET network-monitoring/v1/switches` | Retrieves a single page of switch records with optional filter and sort support. |
+| `get_switch_details` | `GET network-monitoring/v1/switches/{serial_number}` | Retrieves details for a specific switch by serial number, stack ID, or conductor serial. |
+| `get_stack_members` | `GET network-monitoring/v1/stack/{serial_number}/members` | Retrieves stack member details for a given stack ID or conductor serial. |
+| `get_switch_hardware_categories` | `GET network-monitoring/v1/switches/{serial_number}/hardware-categories` | Retrieves hardware details for a specific switch. |
+| `get_switch_lag` | `GET network-monitoring/v1/switches/{serial_number}/lag` | Retrieves link aggregation group (LAG) summary details for a specific switch. |
+| `get_switch_interfaces` | `GET network-monitoring/v1/switches/{serial_number}/interfaces` | Retrieves interface details for a specific switch with optional filter, search, and sort support. |
+| `get_switch_vlans` | `GET network-monitoring/v1/switches/{serial_number}/vlans` | Retrieves VLAN details for a specific switch with optional filter, search, and sort support. |
+| `get_topn_interface_trends` | `GET network-monitoring/v1/switches/topn-interface-trends` | Retrieves top-N switch interface trends (rx bytes, tx bytes) for a site over a given time period. |
+| `get_switch_interface_trends` | `GET network-monitoring/v1/switches/{serial_number}/interface-trends` | Retrieves interface trend data (RX/TX bytes, discards, errors, etc.) for a specific switch. |
+| `get_switch_hardware_trends` | `GET network-monitoring/v1/switches/{serial_number}/hardware-trends` | Retrieves hardware trend data (CPU, memory, PoE) for a specific switch. |
+| `get_switch_interface_poe` | `GET network-monitoring/v1/switches/{serial_number}/interface-poe` | Retrieves interface PoE details for a specific switch. |
+| `get_switch_vsx` | `GET network-monitoring/v1/switches/{serial_number}/vsx` | Retrieves Virtual Switching Extension (VSX) configuration and operational details for a specific switch. |
+
+---
 
 ## WLANs
 ::: pycentral.new_monitoring.wlans

--- a/docs/modules/new_monitoring.md
+++ b/docs/modules/new_monitoring.md
@@ -7,6 +7,29 @@ Monitoring modules available in the PyCentral SDK are separated by type APs, Cli
 ## APs
 ::: pycentral.new_monitoring.aps
 
+| Module name | API endpoint(s) | Description |
+| --- | --- | --- |
+| `get_all_aps` | `GET network-monitoring/v1/aps` | Retrieves all AP records by paging through the AP listing endpoint. |
+| `get_aps` | `GET network-monitoring/v1/aps` | Retrieves a single page of AP records with optional filter and sort support. |
+| `get_ap_details` | `GET network-monitoring/v1/aps/{serial_number}` | Retrieves details for a specific AP. |
+| `get_ap_trends` | `GET network-monitoring/v1/aps/{serial_number}/throughput-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/cpu-utilization-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/memory-utilization-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/power-consumption-trends` | Retrieves AP trend data for throughput, CPU, memory, or power consumption. |
+| `get_all_radios` | `GET network-monitoring/v1/radios` | Retrieves all fleet radio records by handling pagination automatically. |
+| `get_radios` | `GET network-monitoring/v1/radios` | Retrieves a single page of fleet radios. |
+| `get_all_bssids` | `GET network-monitoring/v1/bssids` | Retrieves all fleet BSSID records by handling pagination automatically. |
+| `get_bssids` | `GET network-monitoring/v1/bssids` | Retrieves a single page of fleet BSSIDs. |
+| `get_all_swarms` | `GET network-monitoring/v1/swarms` | Retrieves all swarm records by handling pagination automatically. |
+| `get_swarms` | `GET network-monitoring/v1/swarms` | Retrieves a single page of swarms. |
+| `get_swarm_details` | `GET network-monitoring/v1/swarms/{cluster_id}` | Retrieves details for a specific swarm cluster. |
+| `get_ap_radios` | `GET network-monitoring/v1/aps/{serial_number}/radios` | Retrieves radios associated with a specific AP. |
+| `get_ap_radio_trends` | `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/throughput-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/channel-utilization-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/channel-quality-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/noise-floor-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/frames-trends` | Retrieves trend data for a specific radio on an AP. |
+| `get_ap_ports` | `GET network-monitoring/v1/aps/{serial_number}/ports` | Retrieves port information for a specific AP. |
+| `get_ap_port_trends` | `GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/throughput-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/frames-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/crc-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/collisions-trends` | Retrieves trend data for a specific AP port. |
+| `get_all_ap_tunnels` | `GET network-monitoring/v1/aps/{serial_number}/tunnels` | Retrieves all tunnel records for an AP by handling pagination automatically. |
+| `get_ap_tunnels` | `GET network-monitoring/v1/aps/{serial_number}/tunnels` | Retrieves a single page of tunnel records for an AP. |
+| `get_ap_tunnel_details` | `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}` | Retrieves details for a specific tunnel on an AP. |
+| `get_ap_tunnel_trends` | `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/throughput-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/packet-loss-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/mos-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/jitter-trends`<br>`GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/latency-trends` | Retrieves trend data for a specific AP tunnel. |
+| `get_ap_wlans` | `GET network-monitoring/v1/aps/{serial_number}/wlans` | Retrieves WLANs associated with a specific AP. |
+
 ---
 
 ## Clients
@@ -22,6 +45,43 @@ Monitoring modules available in the PyCentral SDK are separated by type APs, Cli
 ## Gateways
 ::: pycentral.new_monitoring.gateways
 
+| Module name | API endpoint(s) | Description |
+| --- | --- | --- |
+| `get_all_gateways` | `GET network-monitoring/v1/gateways` | Retrieves all gateways by paging through the gateway listing endpoint. |
+| `get_gateways` | `GET network-monitoring/v1/gateways` | Retrieves a single page of gateway records with optional filter and sort support. |
+| `get_gateway_details` | `GET network-monitoring/v1/gateways/{serial_number}` | Retrieves details for a specific gateway. |
+| `get_all_gateway_ports` | `GET network-monitoring/v1/gateways/{serial_number}/ports` | Retrieves all gateway port records by handling pagination automatically. |
+| `get_gateway_ports` | `GET network-monitoring/v1/gateways/{serial_number}/ports` | Retrieves a single page of gateway ports with optional filter and sort support. |
+| `get_gateway_port_details` | `GET network-monitoring/v1/gateways/{serial_number}/ports/{port_number}` | Retrieves details for a specific gateway port. |
+| `get_all_gateway_vlans` | `GET network-monitoring/v1/gateways/{serial_number}/vlans` | Retrieves all gateway VLAN records by handling pagination automatically. |
+| `get_gateway_vlans` | `GET network-monitoring/v1/gateways/{serial_number}/vlans` | Retrieves a single page of gateway VLANs with optional filter and sort support. |
+| `get_gateway_vlan_details` | `GET network-monitoring/v1/gateways/{serial_number}/vlans/{vlan_id}` | Retrieves details for a specific gateway VLAN. |
+| `get_all_gateway_tunnels` | `GET network-monitoring/v1/gateways/{serial_number}/tunnels` | Retrieves all gateway tunnel records by handling pagination automatically. |
+| `get_gateway_tunnels` | `GET network-monitoring/v1/gateways/{serial_number}/tunnels` | Retrieves a single page of gateway tunnels with optional filter and sort support. |
+| `get_gateway_tunnel_details` | `GET network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}` | Retrieves details for a specific gateway tunnel. |
+| `get_gateway_uplinks` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks` | Retrieves all uplinks for a gateway with optional sort support. |
+| `get_gateway_uplink_details` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}` | Retrieves details for a specific gateway uplink. |
+| `get_all_gateway_dhcp_pools` | `GET network-monitoring/v1/gateways/{serial_number}/dhcp-pools` | Retrieves all gateway DHCP pool records by handling pagination automatically. |
+| `get_gateway_dhcp_pools` | `GET network-monitoring/v1/gateways/{serial_number}/dhcp-pools` | Retrieves a single page of gateway DHCP pools with optional sort support. |
+| `get_all_gateway_dhcp_clients` | `GET network-monitoring/v1/gateways/{serial_number}/dhcp-clients` | Retrieves all gateway DHCP client records by handling pagination automatically. |
+| `get_gateway_dhcp_clients` | `GET network-monitoring/v1/gateways/{serial_number}/dhcp-clients` | Retrieves a single page of gateway DHCP clients with optional filter and sort support. |
+| `get_gateway_trends` | `GET network-monitoring/v1/gateways/{serial_number}/cpu-utilization-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/memory-utilization-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/wan-availability-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/vpn-availability-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/hardware-temperature-trends` | Retrieves gateway trend data for a specified metric (cpu-utilization, memory-utilization, wan-availability, vpn-availability, hardware-temperature). |
+| `get_gateway_port_trends` | `GET network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/throughput-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/frames-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/frames-errors-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/frames-packets-trends` | Retrieves trend data for a gateway port metric (throughput, frames, frames-errors, frames-packets). |
+| `get_gateway_tunnel_trends` | `GET network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}/throughput-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}/status-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}/dropped-packet-trends` | Retrieves trend data for a gateway tunnel metric (throughput, status, dropped-packets). |
+| `get_gateway_uplink_trends` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/throughput-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/wan-compression-trends`<br>`GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/wan-availability-trends` | Retrieves trend data for a gateway uplink metric (throughput, wan-compression, wan-availability). |
+| `get_gateway_uplink_vpn_availability_trends` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks/{vlan_id}/vpn-availability-trends` | Retrieves VPN availability trends for a gateway uplink using a VLAN identifier. |
+| `get_gateway_uplink_probes` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes` | Retrieves probe definitions for a specific gateway uplink. |
+| `get_gateway_uplink_probe_performance_trends` | `GET network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes/{probe}/performance-trends` | Retrieves performance trends for a specific gateway uplink probe. |
+| `get_gateway_tunnel_health_summary` | `GET network-monitoring/v1/gateways/{serial_number}/lan-tunnels-health-summary`<br>`GET network-monitoring/v1/gateways/{serial_number}/wan-tunnels-health-summary` | Retrieves LAN or WAN tunnel health summary for a gateway. |
+| `get_all_cluster_members` | `GET network-monitoring/v1/clusters/{cluster_name}/members` | Retrieves all cluster member records by handling pagination automatically. |
+| `get_cluster_members` | `GET network-monitoring/v1/clusters/{cluster_name}/members` | Retrieves a single page of cluster members with optional filter and sort support. |
+| `get_all_cluster_tunnels` | `GET network-monitoring/v1/clusters/{cluster_name}/tunnels` | Retrieves all cluster tunnel records by handling pagination automatically. |
+| `get_cluster_tunnels` | `GET network-monitoring/v1/clusters/{cluster_name}/tunnels` | Retrieves a single page of cluster tunnels with optional filter and sort support. |
+| `get_cluster_vlan_mismatch` | `GET network-monitoring/v1/clusters/{cluster_name}/vlan-mismatch` | Retrieves VLAN mismatch details for a cluster. |
+| `get_cluster_connectivity_graph` | `GET network-monitoring/v1/clusters/{cluster_name}/connectivity-graph` | Retrieves connectivity graph details for a cluster. |
+| `get_cluster_tunnel_summary` | `GET network-monitoring/v1/clusters/{cluster_name}/tunnels-health-summary`<br>`GET network-monitoring/v1/clusters/{cluster_name}/tunnels-status-summary` | Retrieves cluster tunnel health or status summary. |
+| `get_cluster_capacity_trends` | `GET network-monitoring/v1/clusters/{cluster_name}/capacity-trends`<br>`GET network-monitoring/v1/clusters/{cluster_name}/capacity-trends/{serial_number}` | Retrieves cluster capacity trends, optionally scoped to a specific cluster member by serial number. |
+
 ---
 
 ## Sites
@@ -31,3 +91,12 @@ Monitoring modules available in the PyCentral SDK are separated by type APs, Cli
 
 ## Switches
 ::: pycentral.new_monitoring.switches
+
+
+## WLANs
+::: pycentral.new_monitoring.wlans
+
+| Module name | API endpoint(s) | Description |
+| --- | --- | --- |
+| `get_all_wlans` | `GET network-monitoring/v1/wlans` | Retrieves all WLAN records by paging through the WLAN listing endpoint. |
+| `get_wlans` | `GET network-monitoring/v1/wlans` | Retrieves a single page of WLAN records with optional site, AP serial, filter, and sort criteria. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,12 +47,12 @@ nav:
       - Base Module: modules/base.md
       - Exceptions: modules/exceptions.md
       - GLP: modules/glp.md
-      - MSP: modules/msp.md
-      - Monitoring: modules/new_monitoring.md
       - Profiles: modules/profiles.md
+      - MSP: modules/msp.md
+      - New Monitoring: modules/new_monitoring.md
       - Scopes: modules/scopes.md
-      - Streaming: modules/streaming.md
       - Troubleshooting: modules/troubleshooting.md
+      - Streaming: modules/streaming.md
       - Utils: modules/utils.md
       - Classic Modules: modules/classic.md
 

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a19"
+__version__ = "2.0a20"
 
 from .base import NewCentralBase
 from .msp import MSPBase

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -328,6 +328,23 @@ class NewCentralBase:
                     )
                     self._renew_token(route["token_key"])
                     retry += 1
+                elif resp.status_code == 429:
+                    # Allowing one retry on 429 in case rate limit hit
+                    # Pausing 1 second should allow the retry to succeed
+                    # if it doesn't, we log the error and exit
+                    if retry >= 2:
+                        self.logger.error(
+                            f"Received error 429 on requesting url "
+                            f"{url} with resp {resp.text}. Retry attempts exhausted."
+                        )
+                        limit_reached = True
+                        break
+                    self.logger.info(
+                        f"Received error 429 - {app_name} rate limit reached."
+                        f" Pausing before retry {retry + 1}/2..."
+                    )
+                    time.sleep(1)
+                    retry += 1
                 else:
                     break
 

--- a/pycentral/base.py
+++ b/pycentral/base.py
@@ -247,7 +247,7 @@ class NewCentralBase:
         files=None,
     ):
         """
-        Execute an API command to HPE Aruba Networking Central or GreenLake Platform.
+        Execute an API command to Central or GreenLake Platform.
 
         This is the primary method for making API calls from the SDK. It handles
         authentication, token refresh on expiry, request formatting, and response
@@ -267,7 +267,7 @@ class NewCentralBase:
             api_path (str): API endpoint path (e.g., "monitoring/v1/aps").
                 This is appended to the base_url configured in token_info.
             app_name (str, optional): Target application for the API call.
-                Use "new_central" for HPE Aruba Networking Central APIs (default).
+                Use "new_central" for Central APIs (default).
                 Use "glp" for GreenLake Platform APIs.
             api_data (dict, optional): Request body/payload to be sent. Automatically
                 serialized to JSON if Content-Type is application/json. Defaults to None.

--- a/pycentral/exceptions/login_error.py
+++ b/pycentral/exceptions/login_error.py
@@ -7,7 +7,7 @@ from pycentral.exceptions.pycentral_error import PycentralError
 class LoginError(PycentralError):
     """Exception raised when login or authentication fails.
 
-    This exception is raised when authentication to HPE Aruba Networking Central fails,
+    This exception is raised when authentication to Central fails,
     typically due to invalid credentials, expired tokens, or network issues.
 
     Attributes:

--- a/pycentral/new_monitoring/__init__.py
+++ b/pycentral/new_monitoring/__init__.py
@@ -4,3 +4,4 @@ from .gateways import MonitoringGateways
 from .sites import MonitoringSites
 from .clients import Clients
 from .switches import MonitoringSwitches
+from .wlans import WLAN

--- a/pycentral/new_monitoring/aps.py
+++ b/pycentral/new_monitoring/aps.py
@@ -1,23 +1,58 @@
-from ..utils.monitoring_utils import (
-    execute_get,
-    generate_timestamp_str,
-    clean_raw_trend_data,
-    merged_dict_to_sorted_list,
-    validate_device_serial,
-)
 from ..exceptions import ParameterError
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from ..utils.monitoring_utils import (
+    build_trend_params,
+    execute_get,
+    get_all_pages,
+    normalize_metric,
+    normalize_trend_response,
+    validate_central_conn_and_serial,
+    validate_limit_and_next,
+    validate_query_length,
+    validate_required_value,
+    validate_site_id,
+)
+from .constants import AP_LIMIT, BSSID_LIMIT, RADIO_LIMIT, SWARM_LIMIT, TUNNEL_LIMIT
 
-AP_LIMIT = 100
-WLAN_LIMIT = 100
 MONITOR_TYPE = "aps"
+
+AP_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "cpu-utilization": "cpu-utilization-trends",
+    "memory-utilization": "memory-utilization-trends",
+    "power-consumption": "power-consumption-trends",
+}
+RADIO_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "channel-utilization": "channel-utilization-trends",
+    "channel-quality": "channel-quality-trends",
+    "noise-floor": "noise-floor-trends",
+    "frames": "frames-trends",
+}
+PORT_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "frames": "frames-trends",
+    "crc": "crc-trends",
+    "collisions": "collisions-trends",
+}
+TUNNEL_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "packet-loss": "packet-loss-trends",
+    "mos": "mos-trends",
+    "jitter": "jitter-trends",
+    "latency": "latency-trends",
+}
+AP_INTERFACE_TYPES = {"WIRED", "WIRELESS", "LTE"}
 
 
 class MonitoringAPs:
+
     @staticmethod
     def get_all_aps(central_conn, filter_str=None, sort=None):
         """
         Retrieve all access points (APs), handling pagination.
+
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/aps`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
@@ -27,31 +62,13 @@ class MonitoringAPs:
         Returns:
             (list[dict]): List of AP items.
         """
-        aps = []
-        total_aps = None
-        next_page = 1
-        while True:
-            resp = MonitoringAPs.get_aps(
-                central_conn,
-                filter_str=filter_str,
-                sort=sort,
-                limit=AP_LIMIT,
-                next_page=next_page,
-            )
-            if total_aps is None:
-                total_aps = resp.get("total", 0)
-
-            aps.extend(resp["items"])
-
-            if len(aps) == total_aps:
-                break
-
-            next_page = resp.get("next")
-            if not next_page:
-                break
-
-            next_page = int(next_page)
-        return aps
+        return get_all_pages(
+            MonitoringAPs.get_aps,
+            limit=AP_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
 
     @staticmethod
     def get_aps(
@@ -66,7 +83,7 @@ class MonitoringAPs:
             central_conn (NewCentralBase): Central connection object.
             filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
             sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            limit (int, optional): Number of entries to return (default is 100).
+            limit (int, optional): Number of entries to return (default is 1000).
             next_page (int, optional): Pagination cursor/index for next page (default is 1).
 
         Returns:
@@ -75,18 +92,20 @@ class MonitoringAPs:
         Raises:
             ParameterError: If limit or next_page values are invalid.
         """
-        path = MONITOR_TYPE
-        if limit > AP_LIMIT:
-            raise ParameterError(f"limit cannot exceed {AP_LIMIT}")
-        if next_page < 1:
-            raise ParameterError("next_page must be 1 or greater")
-        params = {
-            "filter": filter_str,
-            "sort": sort,
-            "limit": limit,
-            "next": next_page,
-        }
-        return execute_get(central_conn, endpoint=path, params=params)
+        validate_limit_and_next(limit, next_page, AP_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=MONITOR_TYPE,
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
 
     @staticmethod
     def get_ap_details(central_conn, serial_number):
@@ -105,305 +124,619 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        validate_device_serial(serial_number=serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}"
-        return execute_get(central_conn, endpoint=path)
+        validate_central_conn_and_serial(central_conn, serial_number)
+        return execute_get(central_conn, endpoint=f"{MONITOR_TYPE}/{serial_number}")
 
     @staticmethod
-    def get_ap_stats(
+    def _execute_trend_request(
         central_conn,
         serial_number,
+        metric,
+        metric_map,
+        resource_path=None,
         start_time=None,
         end_time=None,
         duration=None,
+        site_id=None,
+        extra_params=None,
+        return_raw_response=False,
+    ):
+        validate_central_conn_and_serial(central_conn, serial_number)
+        metric = normalize_metric(metric, metric_map)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            extra_params=extra_params,
+        )
+        path = f"{MONITOR_TYPE}/{serial_number}"
+        if resource_path:
+            path = f"{path}/{resource_path}"
+        path = f"{path}/{metric_map[metric]}"
+        response = execute_get(central_conn, endpoint=path, params=params)
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_ap_trends(
+        central_conn,
+        serial_number,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        interface_type="WIRELESS",
         return_raw_response=False,
     ):
         """
-        Collect multiple statistics (CPU, memory, power consumption) for an AP for the specified time range. Default is to return sorted trend statistics for last 3 hours.
+        Retrieve trend data for an AP metric.
+
+        This method makes an API call to one of the following endpoints based on `metric` -
+        `GET network-monitoring/v1/aps/{serial_number}/throughput-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/cpu-utilization-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/memory-utilization-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/power-consumption-trends`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
             serial_number (str): Serial number of the AP.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string (e.g. '5m') or seconds for relative queries.
-            return_raw_response (bool, optional): If True, return raw per-metric responses.
-
-        Returns:
-            (list|dict): If return_raw_response is True returns raw list of responses; otherwise returns merged, sorted trend statistics for the AP.
-
-        Raises:
-            ParameterError: If serial_number is missing/invalid.
-            RuntimeError: If any of the parallel metric requests fail.
-        """
-        validate_device_serial(serial_number)
-
-        # dispatch the three metric calls in parallel; helper methods handle timestamp logic
-        funcs = [
-            MonitoringAPs.get_ap_cpu_utilization,
-            MonitoringAPs.get_ap_memory_utilization,
-            MonitoringAPs.get_ap_poe_utilization,
-        ]
-
-        raw_results = []
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            future_map = {
-                executor.submit(
-                    func,
-                    central_conn,
-                    serial_number,
-                    start_time,
-                    end_time,
-                    duration,
-                ): func
-                for func in funcs
-            }
-            for fut in as_completed(future_map):
-                func = future_map[fut]
-                try:
-                    resp = fut.result()
-                    raw_results.append(resp)
-                except Exception as e:
-                    # propagate the error for the caller to handle, but include which call failed
-                    raise RuntimeError(
-                        f"{func.__name__} metrics request failed: {e}"
-                    ) from e
-
-        if return_raw_response:
-            return raw_results
-
-        data = {}
-        for resp in raw_results:
-            if not isinstance(resp, dict):
-                continue
-            data = clean_raw_trend_data(resp, data=data)
-        data = merged_dict_to_sorted_list(data)
-        return data
-
-    @staticmethod
-    def get_latest_ap_stats(
-        central_conn,
-        serial_number,
-    ):
-        """
-        Get the latest AP statistics (like CPU, memory, power consumption).
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the AP.
-
-        Returns:
-            (dict): Latest statistics for the AP, or empty dict if none exist.
-
-        Raises:
-            ParameterError: If serial_number is missing/invalid.
-        """
-        validate_device_serial(serial_number)
-        stats = MonitoringAPs.get_ap_stats(
-            central_conn, serial_number, duration="5m"
-        )
-        if stats and isinstance(stats, list) and len(stats) > 0:
-            return stats[-1]
-        else:
-            return {}
-
-    @staticmethod
-    def get_ap_cpu_utilization(
-        central_conn,
-        serial_number,
-        start_time=None,
-        end_time=None,
-        duration=None,
-    ):
-        """
-        Retrieve CPU utilization trends for an AP.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1/aps/{serial_number}/cpu-utilization-trends`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the AP.
+            metric (str): Trend metric to retrieve. Supported values are `throughput`, `cpu-utilization`, `memory-utilization`, and `power-consumption`.
             start_time (int, optional): Start time (epoch seconds) for range queries.
             end_time (int, optional): End time (epoch seconds) for range queries.
             duration (str|int, optional): Duration string or seconds for relative queries.
+            site_id (str, optional): Site identifier to scope the trend request.
+            interface_type (str, optional): Interface type for throughput requests. Supported values are `WIRED`, `WIRELESS`, and `LTE`.
+            return_raw_response (bool, optional): If True, return the raw API payload. Otherwise return normalized trend samples.
 
         Returns:
-            (dict|list): API response for cpu-utilization-trends.
+            (dict|list): If return_raw_response is True returns the raw API response; otherwise returns normalized trend samples.
 
         Raises:
-            ParameterError: If serial_number is missing/invalid.
+            ParameterError: If serial_number, metric, or interface_type is invalid.
         """
-        validate_device_serial(serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}/cpu-utilization-trends"
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(central_conn, endpoint=path)
+        extra_params = None
+        normalized_metric = normalize_metric(metric, AP_TREND_METRICS)
+        if normalized_metric == "throughput":
+            normalized_interface_type = str(interface_type).upper()
+            if normalized_interface_type not in AP_INTERFACE_TYPES:
+                supported = ", ".join(sorted(AP_INTERFACE_TYPES))
+                raise ParameterError(
+                    "interface_type must be one of "
+                    f"{supported} for AP throughput trends"
+                )
+            extra_params = {"interface-type": normalized_interface_type}
+
+        return MonitoringAPs._execute_trend_request(
+            central_conn=central_conn,
+            serial_number=serial_number,
+            metric=normalized_metric,
+            metric_map=AP_TREND_METRICS,
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            extra_params=extra_params,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_all_radios(central_conn, filter_str=None, sort=None):
+        """
+        Retrieve all fleet radios, handling pagination.
+
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/radios`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): Optional filter expression for the radio list.
+            sort (str, optional): Optional sort expression for the radio list.
+
+        Returns:
+            (list[dict]): List of radio items.
+        """
+        return get_all_pages(
+            MonitoringAPs.get_radios,
+            limit=RADIO_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_radios(
+        central_conn, filter_str=None, sort=None, limit=RADIO_LIMIT, next_page=1
+    ):
+        """
+        Retrieve a single page of fleet radios.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/radios`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): Optional filter expression for the radio list.
+            sort (str, optional): Optional sort expression for the radio list.
+            limit (int, optional): Number of entries to return.
+            next_page (int, optional): Pagination cursor/index for the next page.
+
+        Returns:
+            (dict): API response for the radios endpoint.
+
+        Raises:
+            ParameterError: If limit, next_page, filter_str, or sort is invalid.
+        """
+        validate_limit_and_next(limit, next_page, RADIO_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
         return execute_get(
             central_conn,
-            endpoint=path,
+            endpoint="radios",
             params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
             },
         )
 
     @staticmethod
-    def get_ap_memory_utilization(
-        central_conn,
-        serial_number,
-        start_time=None,
-        end_time=None,
-        duration=None,
-    ):
+    def get_all_bssids(central_conn, filter_str=None, sort=None):
         """
-        Retrieve memory utilization trends for an AP.
+        Retrieve all fleet BSSIDs, handling pagination.
 
-        This method makes an API call to the following endpoint -  `GET network-monitoring/v1/aps/{serial_number}/memory-utilization-trends`
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/bssids`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the AP.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string or seconds for relative queries.
+            filter_str (str, optional): Optional filter expression for the BSSID list.
+            sort (str, optional): Optional sort expression for the BSSID list.
 
         Returns:
-            (dict|list): API response for memory-utilization-trends.
+            (list[dict]): List of BSSID items.
+        """
+        return get_all_pages(
+            MonitoringAPs.get_bssids,
+            limit=BSSID_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_bssids(
+        central_conn, filter_str=None, sort=None, limit=BSSID_LIMIT, next_page=1
+    ):
+        """
+        Retrieve a single page of fleet BSSIDs.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/bssids`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): Optional filter expression for the BSSID list.
+            sort (str, optional): Optional sort expression for the BSSID list.
+            limit (int, optional): Number of entries to return.
+            next_page (int, optional): Pagination cursor/index for the next page.
+
+        Returns:
+            (dict): API response for the bssids endpoint.
 
         Raises:
-            ParameterError: If serial_number is missing/invalid.
+            ParameterError: If limit, next_page, filter_str, or sort is invalid.
         """
-        validate_device_serial(serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}/memory-utilization-trends"
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(
-                central_conn,
-                endpoint=path,
-            )
+        validate_limit_and_next(limit, next_page, BSSID_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
         return execute_get(
             central_conn,
-            endpoint=path,
+            endpoint="bssids",
             params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
             },
         )
 
     @staticmethod
-    def get_ap_poe_utilization(
-        central_conn,
-        serial_number,
-        start_time=None,
-        end_time=None,
-        duration=None,
-    ):
+    def get_all_swarms(central_conn, filter_str=None, sort=None):
         """
-        Retrieve power consumption trends for an AP.
+        Retrieve all swarms, handling pagination.
 
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1/aps/{serial_number}/power-consumption-trends`
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/swarms`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the AP.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string or seconds for relative queries.
+            filter_str (str, optional): Optional filter expression for the swarm list.
+            sort (str, optional): Optional sort expression for the swarm list.
 
         Returns:
-            (dict|list): API response for power-consumption-trends.
+            (list[dict]): List of swarm items.
+        """
+        return get_all_pages(
+            MonitoringAPs.get_swarms,
+            limit=SWARM_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_swarms(
+        central_conn, filter_str=None, sort=None, limit=SWARM_LIMIT, next_page=1
+    ):
+        """
+        Retrieve a single page of swarms.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/swarms`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            filter_str (str, optional): Optional filter expression for the swarm list.
+            sort (str, optional): Optional sort expression for the swarm list.
+            limit (int, optional): Number of entries to return.
+            next_page (int, optional): Pagination cursor/index for the next page.
+
+        Returns:
+            (dict): API response for the swarms endpoint.
 
         Raises:
-            ParameterError: If serial_number is missing/invalid.
+            ParameterError: If limit, next_page, filter_str, or sort is invalid.
         """
-        validate_device_serial(serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}/power-consumption-trends"
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(
-                central_conn,
-                endpoint=path,
-            )
+        validate_limit_and_next(limit, next_page, SWARM_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
         return execute_get(
             central_conn,
-            endpoint=path,
+            endpoint="swarms",
             params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
             },
         )
 
     @staticmethod
-    def get_wlans(
+    def get_swarm_details(central_conn, cluster_id):
+        """
+        Get details for a specific swarm.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/swarms/{cluster_id}`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            cluster_id (str): Cluster identifier for the swarm.
+
+        Returns:
+            (dict): API response with swarm details.
+
+        Raises:
+            ParameterError: If cluster_id is missing.
+        """
+        validate_required_value("cluster_id", cluster_id)
+        return execute_get(central_conn, endpoint=f"swarms/{cluster_id}")
+
+    @staticmethod
+    def get_ap_radios(central_conn, serial_number):
+        """
+        Retrieve radios associated with an AP.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/aps/{serial_number}/radios`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+
+        Returns:
+            (dict): API response with radio details for the AP.
+
+        Raises:
+            ParameterError: If serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        return execute_get(central_conn, endpoint=f"{MONITOR_TYPE}/{serial_number}/radios")
+
+    @staticmethod
+    def get_ap_radio_trends(
         central_conn,
+        serial_number,
+        radio_number,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
         site_id=None,
-        serial_number=None,
+        return_raw_response=False,
+    ):
+        """
+        Retrieve trend data for a radio under an AP.
+
+        This method makes an API call to one of the following endpoints based on `metric` -
+        `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/throughput-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/channel-utilization-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/channel-quality-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/noise-floor-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/frames-trends`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+            radio_number (str|int): Radio number under the AP.
+            metric (str): Radio trend metric to retrieve.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string or seconds for relative queries.
+            site_id (str, optional): Site identifier to scope the trend request.
+            return_raw_response (bool, optional): If True, return the raw API payload. Otherwise return normalized trend samples.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns the raw API response; otherwise returns normalized trend samples.
+
+        Raises:
+            ParameterError: If serial_number, radio_number, or metric is invalid.
+        """
+        validate_required_value("radio_number", radio_number)
+        return MonitoringAPs._execute_trend_request(
+            central_conn=central_conn,
+            serial_number=serial_number,
+            metric=metric,
+            metric_map=RADIO_TREND_METRICS,
+            resource_path=f"radios/{radio_number}",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_ap_ports(central_conn, serial_number):
+        """
+        Retrieve ports associated with an AP.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/aps/{serial_number}/ports`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+
+        Returns:
+            (dict): API response with port details for the AP.
+
+        Raises:
+            ParameterError: If serial_number is missing/invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        return execute_get(central_conn, endpoint=f"{MONITOR_TYPE}/{serial_number}/ports")
+
+    @staticmethod
+    def get_ap_port_trends(
+        central_conn,
+        serial_number,
+        port_index,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """
+        Retrieve trend data for a port under an AP.
+
+        This method makes an API call to one of the following endpoints based on `metric` -
+        `GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/throughput-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/frames-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/crc-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/ports/{port_index}/collisions-trends`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+            port_index (str|int): Port index under the AP.
+            metric (str): Port trend metric to retrieve.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string or seconds for relative queries.
+            site_id (str, optional): Site identifier to scope the trend request.
+            return_raw_response (bool, optional): If True, return the raw API payload. Otherwise return normalized trend samples.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns the raw API response; otherwise returns normalized trend samples.
+
+        Raises:
+            ParameterError: If serial_number, port_index, or metric is invalid.
+        """
+        validate_required_value("port_index", port_index)
+        return MonitoringAPs._execute_trend_request(
+            central_conn=central_conn,
+            serial_number=serial_number,
+            metric=metric,
+            metric_map=PORT_TREND_METRICS,
+            resource_path=f"ports/{port_index}",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_all_ap_tunnels(
+        central_conn,
+        serial_number,
+        site_id=None,
         filter_str=None,
         sort=None,
-        limit=WLAN_LIMIT,
+    ):
+        """
+        Retrieve all AP tunnels, handling pagination.
+
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+            site_id (str, optional): Site identifier for the tunnel list.
+            filter_str (str, optional): Optional filter expression for the tunnel list.
+            sort (str, optional): Optional sort expression for the tunnel list.
+
+        Returns:
+            (list[dict]): List of tunnel items for the AP.
+        """
+        return get_all_pages(
+            MonitoringAPs.get_ap_tunnels,
+            limit=TUNNEL_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            site_id=site_id,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_ap_tunnels(
+        central_conn,
+        serial_number,
+        site_id=None,
+        filter_str=None,
+        sort=None,
+        limit=TUNNEL_LIMIT,
         next_page=1,
     ):
         """
-        Retrieve a list of WLANs associated to a customer.
+        Retrieve a single page of AP tunnels.
 
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1/wlans`
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
-            site_id (str, optional): ID of the Site for which WLAN information is requested. Max length 128.
-            serial_number (str, optional): Serial number of an access point device. Max length 16.
-            filter_str (str, optional): OData Version 4.0 filter string (limited functionality). 
-                Supports only 'and' conjunction ('or' and 'not' are NOT supported). 
-                Supported field: band (operators: eq, in). Max length 256.
-            sort (str, optional): Comma separated list of sort expressions. Supported fields: 
-                wlanName, band, status, securityLevel, security, vlan, primaryUsage. Max length 256.
-            limit (int, optional): Maximum number of WLANs to return (0-100, default is 20).
-            next_page (int, optional): Pagination cursor for next page (default is 1).
+            serial_number (str): Serial number of the AP.
+            site_id (str, optional): Site identifier for the tunnel list.
+            filter_str (str, optional): Optional filter expression for the tunnel list.
+            sort (str, optional): Optional sort expression for the tunnel list.
+            limit (int, optional): Number of entries to return.
+            next_page (int, optional): Pagination cursor/index for the next page.
 
         Returns:
-            (dict): API response containing:
-                - items (list): List of WLAN dictionaries with fields like wlanName, primaryUsage,
-                    securityLevel, security, band, status, vlan, id, type.
-                - count (int): Number of WLANs in current response.
-                - total (int): Total number of WLANs matching the criteria.
-                - next (str|None): Pagination cursor for the next page.
+            (dict): API response for the AP tunnels endpoint.
 
         Raises:
-            ParameterError: If limit exceeds 100 or next_page is less than 1.
-            ParameterError: If site_id exceeds 128 characters.
-            ParameterError: If serial_number exceeds 16 characters.
-            ParameterError: If filter_str exceeds 256 characters.
-            ParameterError: If sort exceeds 256 characters.
+            ParameterError: If serial_number, limit, next_page, site_id, filter_str, or sort is invalid.
         """
-        path = "wlans"
-        
-        if limit > WLAN_LIMIT:
-            raise ParameterError(f"limit cannot exceed {WLAN_LIMIT}")
-        if next_page < 1:
-            raise ParameterError("next_page must be 1 or greater")
-        
-        if site_id is not None and len(site_id) > 128:
-            raise ParameterError("site_id cannot exceed 128 characters")
-        if serial_number is not None and len(serial_number) > 16:
-            raise ParameterError("serial_number cannot exceed 16 characters")
-        if filter_str is not None and len(filter_str) > 256:
-            raise ParameterError("filter_str cannot exceed 256 characters")
-        if sort is not None and len(sort) > 256:
-            raise ParameterError("sort cannot exceed 256 characters")
-        
-        params = {
-            "site-id": site_id,
-            "serial-number": serial_number,
-            "filter": filter_str,
-            "sort": sort,
-            "limit": limit,
-            "next": next_page,
-        }
-        return execute_get(central_conn, endpoint=path, params=params)
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_limit_and_next(limit, next_page, TUNNEL_LIMIT)
+        validate_site_id(site_id)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/tunnels",
+            params={
+                "site-id": site_id,
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
+
+    @staticmethod
+    def get_ap_tunnel_details(central_conn, serial_number, tunnel_id):
+        """
+        Retrieve details for a tunnel under an AP.
+
+        This method makes an API call to the following endpoint -
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+            tunnel_id (str): Tunnel identifier under the AP.
+
+        Returns:
+            (dict): API response with tunnel details.
+
+        Raises:
+            ParameterError: If serial_number or tunnel_id is invalid.
+        """
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("tunnel_id", tunnel_id)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/tunnels/{tunnel_id}",
+        )
+
+    @staticmethod
+    def get_ap_tunnel_trends(
+        central_conn,
+        serial_number,
+        tunnel_id,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """
+        Retrieve trend data for a tunnel under an AP.
+
+        This method makes an API call to one of the following endpoints based on `metric` -
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/throughput-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/packet-loss-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/mos-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/jitter-trends`
+        `GET network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/latency-trends`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            serial_number (str): Serial number of the AP.
+            tunnel_id (str): Tunnel identifier under the AP.
+            metric (str): Tunnel trend metric to retrieve.
+            start_time (int, optional): Start time (epoch seconds) for range queries.
+            end_time (int, optional): End time (epoch seconds) for range queries.
+            duration (str|int, optional): Duration string or seconds for relative queries.
+            site_id (str, optional): Site identifier to scope the trend request.
+            return_raw_response (bool, optional): If True, return the raw API payload. Otherwise return normalized trend samples.
+
+        Returns:
+            (dict|list): If return_raw_response is True returns the raw API response; otherwise returns normalized trend samples.
+
+        Raises:
+            ParameterError: If serial_number, tunnel_id, or metric is invalid.
+        """
+        validate_required_value("tunnel_id", tunnel_id)
+        return MonitoringAPs._execute_trend_request(
+            central_conn=central_conn,
+            serial_number=serial_number,
+            metric=metric,
+            metric_map=TUNNEL_TREND_METRICS,
+            resource_path=f"tunnels/{tunnel_id}",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
     def get_ap_wlans(central_conn, serial_number):
         """
         Retrieve WLANs associated with an AP.
@@ -420,8 +753,5 @@ class MonitoringAPs:
         Raises:
             ParameterError: If serial_number is missing/invalid.
         """
-        validate_device_serial(serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}/wlans"
-        return execute_get(central_conn, endpoint=path)
-
-
+        validate_central_conn_and_serial(central_conn, serial_number)
+        return execute_get(central_conn, endpoint=f"{MONITOR_TYPE}/{serial_number}/wlans")

--- a/pycentral/new_monitoring/clients.py
+++ b/pycentral/new_monitoring/clients.py
@@ -4,8 +4,7 @@ from ..utils.monitoring_utils import (
     _validate_mac_address,
 )
 from ..exceptions import ParameterError
-
-CLIENT_LIMIT = 1000
+from .constants import CLIENT_LIMIT
 
 
 class Clients:

--- a/pycentral/new_monitoring/constants.py
+++ b/pycentral/new_monitoring/constants.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+# MIT License
+
+"""Constants for the new_monitoring module.
+
+Defines API pagination limits used across monitoring classes.
+"""
+
+AP_LIMIT = 1000
+RADIO_LIMIT = 1000
+BSSID_LIMIT = 1000
+SWARM_LIMIT = 1000
+TUNNEL_LIMIT = 1000
+GATEWAY_LIMIT = 100
+GATEWAY_VLAN_LIMIT = 100
+GATEWAY_DHCP_LIMIT = 100
+CLUSTER_LIMIT = 100
+SWITCH_LIMIT = 1000
+DEVICE_LIMIT = 1000
+SITE_LIMIT = 100
+CLIENT_LIMIT = 1000
+WLAN_LIMIT = 1000
+
+__all__ = [
+    "AP_LIMIT",
+    "RADIO_LIMIT",
+    "BSSID_LIMIT",
+    "SWARM_LIMIT",
+    "TUNNEL_LIMIT",
+    "GATEWAY_LIMIT",
+    "GATEWAY_VLAN_LIMIT",
+    "GATEWAY_DHCP_LIMIT",
+    "CLUSTER_LIMIT",
+    "SWITCH_LIMIT",
+    "DEVICE_LIMIT",
+    "SITE_LIMIT",
+    "CLIENT_LIMIT",
+    "WLAN_LIMIT",
+]

--- a/pycentral/new_monitoring/devices.py
+++ b/pycentral/new_monitoring/devices.py
@@ -1,8 +1,8 @@
 from ..utils.monitoring_utils import execute_get
 from ..exceptions import ParameterError
+from .constants import DEVICE_LIMIT
 
 MONITOR_TYPE = "devices"
-DEVICE_LIMIT = 1000
 
 
 class MonitoringDevices:

--- a/pycentral/new_monitoring/gateways.py
+++ b/pycentral/new_monitoring/gateways.py
@@ -1,299 +1,385 @@
-from ..utils.monitoring_utils import (
-    execute_get,
-    generate_timestamp_str,
-    clean_raw_trend_data,
-    merged_dict_to_sorted_list,
-    validate_central_conn_and_serial,
-)
 from ..exceptions import ParameterError
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from ..utils.monitoring_utils import (
+    build_trend_params,
+    clean_raw_trend_data,
+    execute_get,
+    get_all_pages,
+    merged_dict_to_sorted_list,
+    normalize_metric,
+    normalize_trend_response,
+    validate_central_conn_and_serial,
+    validate_limit_and_next,
+    validate_query_length,
+    validate_required_value,
+    validate_site_id,
+)
+from .constants import (
+    CLUSTER_LIMIT,
+    GATEWAY_DHCP_LIMIT,
+    GATEWAY_LIMIT,
+    GATEWAY_VLAN_LIMIT,
+)
 
-GATEWAY_LIMIT = 100
 MONITOR_TYPE = "gateways"
-API_VERSION = "v1alpha1"
+CLUSTER_MONITOR_TYPE = "clusters"
+
+GATEWAY_TREND_METRICS = {
+    "cpu-utilization": "cpu-utilization-trends",
+    "memory-utilization": "memory-utilization-trends",
+    "wan-availability": "wan-availability-trends",
+    "vpn-availability": "vpn-availability-trends",
+    "hardware-temperature": "hardware-temperature-trends",
+}
+PORT_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "frames": "frames-trends",
+    "frames-errors": "frames-errors-trends",
+    "frames-packets": "frames-packets-trends",
+}
+TUNNEL_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "status": "status-trends",
+    "dropped-packets": "dropped-packet-trends",
+}
+UPLINK_TREND_METRICS = {
+    "throughput": "throughput-trends",
+    "wan-compression": "wan-compression-trends",
+    "wan-availability": "wan-availability-trends",
+}
 
 
 class MonitoringGateways:
     @staticmethod
     def get_all_gateways(central_conn, filter_str=None, sort=None):
-        """
-        Retrieve all gateways, handling pagination.
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
-            sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-
-        Returns:
-            (list[dict]): List of gateway items.
-        """
-        gateways = []
-        total_gateways = None
-        limit = GATEWAY_LIMIT
-        next = 1
-        # Loop to get all gateways with pagination
-        while True:
-            response = MonitoringGateways.get_gateways(
-                central_conn, limit=limit, next=next
-            )
-            if total_gateways is None:
-                total_gateways = response.get("total", 0)
-            gateways.extend(response.get("items", []))
-            if len(gateways) >= total_gateways:
-                break
-            next += 1
-
-        return gateways
+        """Retrieve all gateways, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateways,
+            limit=GATEWAY_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
 
     @staticmethod
     def get_gateways(
-        central_conn, filter_str=None, sort=None, limit=GATEWAY_LIMIT, next=1
+        central_conn,
+        filter_str=None,
+        sort=None,
+        limit=GATEWAY_LIMIT,
+        next_page=1,
     ):
-        """
-        Retrieve a single page of gateways, including optional filtering and sorting as supported by the API.
+        """Retrieve a single page of gateways."""
+        validate_limit_and_next(limit, next_page, GATEWAY_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
-            sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            limit (int, optional): Number of entries to return (default is 100).
-            next (int, optional): Pagination cursor/index for next page (default is 1).
-
-        Returns:
-            (dict):  API response containing keys like 'items', 'total', and 'next'.
-        """
-        params = {
-            "limit": limit,
-            "next": next,
-            "filter": filter_str,
-            "sort": sort,
-        }
-
-        path = MONITOR_TYPE
-        return execute_get(central_conn, endpoint=path, params=params, version=API_VERSION)
-
-    @staticmethod
-    def get_cluster_leader_details(central_conn, cluster_name):
-        """
-        Get details for the leader of a gateway cluster.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/clusters/{cluster_name}/leader`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            cluster_name (str): Name of the cluster.
-
-        Returns:
-            (dict): API response for the cluster leader.
-
-        Raises:
-            ParameterError: If cluster_name is missing or not a string.
-        """
-        if not cluster_name or not isinstance(cluster_name, str):
-            raise ParameterError(
-                "cluster_name is required and must be a string"
-            )
-        path = f"clusters/{cluster_name}/leader"
-
-        return execute_get(central_conn, endpoint=path, version=API_VERSION)
+        return execute_get(
+            central_conn,
+            endpoint=MONITOR_TYPE,
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
 
     @staticmethod
     def get_gateway_details(central_conn, serial_number):
-        """
-        Get details for a specific gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-
-        Returns:
-            (dict): API response with gateway details.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
+        """Get details for a specific gateway."""
         validate_central_conn_and_serial(central_conn, serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}"
-        return execute_get(central_conn, endpoint=path, version=API_VERSION)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}",
+        )
 
     @staticmethod
-    def get_gateway_interfaces(
+    def get_all_gateway_ports(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all gateway ports, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateway_ports,
+            limit=GATEWAY_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_gateway_ports(
         central_conn,
         serial_number,
         filter_str=None,
         sort=None,
         limit=GATEWAY_LIMIT,
-        next=1,
+        next_page=1,
     ):
-        """
-        Retrieve port/interface details for a gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/ports`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
-            sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            limit (int, optional): Number of entries to return (default is 100).
-            next (int, optional): Pagination cursor/index for next page (default is 1).
-
-        Returns:
-            (dict): API response for the ports endpoint.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
+        """Retrieve a single page of gateway ports."""
         validate_central_conn_and_serial(central_conn, serial_number)
-        params = {
-            "limit": limit,
-            "next": next,
-            "filter": filter_str,
-            "sort": sort,
-        }
-        path = f"{MONITOR_TYPE}/{serial_number}/ports"
-        return execute_get(central_conn, endpoint=path, params=params, version=API_VERSION)
+        validate_limit_and_next(limit, next_page, GATEWAY_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/ports",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
 
     @staticmethod
-    def get_gateway_lan_tunnels(
+    def get_gateway_port_details(central_conn, serial_number, port_number):
+        """Get details for a specific gateway port."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("port_number", port_number)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/ports/{port_number}",
+        )
+
+    @staticmethod
+    def get_all_gateway_vlans(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all gateway VLANs, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateway_vlans,
+            limit=GATEWAY_VLAN_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_gateway_vlans(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+        limit=GATEWAY_VLAN_LIMIT,
+        next_page=1,
+    ):
+        """Retrieve a single page of gateway VLANs."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_limit_and_next(limit, next_page, GATEWAY_VLAN_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/vlans",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
+
+    @staticmethod
+    def get_gateway_vlan_details(central_conn, serial_number, vlan_id):
+        """Get details for a specific gateway VLAN."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("vlan_id", vlan_id)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/vlans/{vlan_id}",
+        )
+
+    @staticmethod
+    def get_all_gateway_tunnels(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all gateway tunnels, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateway_tunnels,
+            limit=GATEWAY_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_gateway_tunnels(
         central_conn,
         serial_number,
         filter_str=None,
         sort=None,
         limit=GATEWAY_LIMIT,
-        next=1,
+        next_page=1,
     ):
-        """
-        Retrieve LAN tunnel details for a gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/lan-tunnels`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            filter_str (str, optional): Optional filter expression (supported fields documented in API Reference Guide).
-            sort (str, optional): Optional sort parameter (supported fields documented in API Reference Guide).
-            limit (int, optional): Number of entries to return (default is 100).
-            next (int, optional): Pagination cursor/index for next page (default is 1).
-
-        Returns:
-            (dict): API response for the lan-tunnels endpoint.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
+        """Retrieve a single page of gateway tunnels."""
         validate_central_conn_and_serial(central_conn, serial_number)
-        params = {
-            "limit": limit,
-            "next": next,
-            "filter": filter_str,
-            "sort": sort,
-        }
-        path = f"{MONITOR_TYPE}/{serial_number}/lan-tunnels"
-        return execute_get(central_conn, endpoint=path, params=params, version=API_VERSION)
+        validate_limit_and_next(limit, next_page, GATEWAY_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/tunnels",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
 
     @staticmethod
-    def get_gateway_stats(
+    def get_gateway_tunnel_details(central_conn, serial_number, tunnel_name):
+        """Get details for a specific gateway tunnel."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("tunnel_name", tunnel_name)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/tunnels/{tunnel_name}"
+        )
+
+    @staticmethod
+    def get_gateway_uplinks(central_conn, serial_number, sort=None):
+        """Retrieve gateway uplinks."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_query_length("sort", sort)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/uplinks",
+            params={"sort": sort}
+        )
+
+    @staticmethod
+    def get_gateway_uplink_details(central_conn, serial_number, link_tag):
+        """Get details for a specific gateway uplink."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("link_tag", link_tag)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/uplinks/{link_tag}"
+        )
+
+    @staticmethod
+    def get_all_gateway_dhcp_pools(
         central_conn,
         serial_number,
+        sort=None,
+    ):
+        """Retrieve all gateway DHCP pools, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateway_dhcp_pools,
+            limit=GATEWAY_DHCP_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_gateway_dhcp_pools(
+        central_conn,
+        serial_number,
+        sort=None,
+        limit=GATEWAY_DHCP_LIMIT,
+        next_page=1,
+    ):
+        """Retrieve a single page of gateway DHCP pools."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_limit_and_next(limit, next_page, GATEWAY_DHCP_LIMIT)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/dhcp-pools",
+            params={
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            }
+        )
+
+    @staticmethod
+    def get_all_gateway_dhcp_clients(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all gateway DHCP clients, handling pagination."""
+        return get_all_pages(
+            MonitoringGateways.get_gateway_dhcp_clients,
+            limit=GATEWAY_DHCP_LIMIT,
+            central_conn=central_conn,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_gateway_dhcp_clients(
+        central_conn,
+        serial_number,
+        filter_str=None,
+        sort=None,
+        limit=GATEWAY_DHCP_LIMIT,
+        next_page=1,
+    ):
+        """Retrieve a single page of gateway DHCP clients."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_limit_and_next(limit, next_page, GATEWAY_DHCP_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/dhcp-clients",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            }
+        )
+
+    @staticmethod
+    def get_gateway_trends(
+        central_conn,
+        serial_number,
+        metric,
         start_time=None,
         end_time=None,
         duration=None,
+        site_id=None,
         return_raw_response=False,
     ):
-        """
-        Collect multiple statistics (like CPU, memory, WAN availability) for a gateway for the specified time range. Default is to return sorted trend statistics for last 3 hours.
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string (e.g. '5m') or seconds for relative queries.
-            return_raw_response (bool, optional): If True, return raw per-metric API responses.
-
-        Returns:
-            (list|dict): If return_raw_response is True returns raw list of responses; otherwise returns merged, sorted trend statistics for the gateway.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-            RuntimeError: If any of the parallel metric requests fail.
-        """
+        """Retrieve trend data for a gateway metric."""
         validate_central_conn_and_serial(central_conn, serial_number)
-
-        # dispatch the three metric calls in parallel; helper methods handle timestamp logic
-        funcs = [
-            MonitoringGateways.get_gateway_cpu_utilization,
-            MonitoringGateways.get_gateway_memory_utilization,
-            MonitoringGateways.get_gateway_wan_availability,
-        ]
-
-        raw_results = []
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            future_map = {
-                executor.submit(
-                    func,
-                    central_conn,
-                    serial_number,
-                    start_time,
-                    end_time,
-                    duration,
-                ): func
-                for func in funcs
-            }
-            for fut in as_completed(future_map):
-                func = future_map[fut]
-                try:
-                    resp = fut.result()
-                    if isinstance(resp, list) is True and len(resp) == 1:
-                        resp = resp[0]
-                    raw_results.append(resp)
-                except Exception as e:
-                    # propagate the error for the caller to handle, but include which call failed
-                    raise RuntimeError(
-                        f"{func.__name__} metrics request failed: {e}"
-                    ) from e
-
-        if return_raw_response:
-            return raw_results
-
-        data = {}
-        for resp in raw_results:
-            if not isinstance(resp, dict):
-                continue
-            data = clean_raw_trend_data(resp, data=data)
-        data = merged_dict_to_sorted_list(data)
-        return data
-
-    def get_latest_gateway_stats(
-        central_conn,
-        serial_number,
-    ):
-        """
-        Get the latest gateway statistics (like CPU, memory, WAN availability)
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-
-        Returns:
-            (dict): Latest statistics for the gateway, or empty dict if none exist.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
-        validate_central_conn_and_serial(central_conn, serial_number)
-        stats = MonitoringGateways.get_gateway_stats(
-            central_conn, serial_number, duration="5m"
+        metric = normalize_metric(metric, GATEWAY_TREND_METRICS)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
         )
-        if stats and isinstance(stats, list) and len(stats) > 0:
-            return stats[-1]
-        else:
-            return {}
+        response = execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/{GATEWAY_TREND_METRICS[metric]}",
+            params=params,
+        )
+        return normalize_trend_response(response, return_raw_response)
 
     @staticmethod
     def get_gateway_cpu_utilization(
@@ -302,42 +388,19 @@ class MonitoringGateways:
         start_time=None,
         end_time=None,
         duration=None,
+        site_id=None,
+        return_raw_response=False,
     ):
-        """
-        Retrieve CPU utilization trends for a gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/cpu-utilization-trends`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string or seconds for relative queries.
-
-        Returns:
-            (dict|list): API response for cpu-utilization-trends.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
-        validate_central_conn_and_serial(central_conn, serial_number)
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(
-                central_conn,
-                endpoint=f"{MONITOR_TYPE}/{serial_number}/cpu-utilization-trends",
-                version=API_VERSION,
-            )
-
-        return execute_get(
+        """Retrieve CPU utilization trends for a gateway."""
+        return MonitoringGateways.get_gateway_trends(
             central_conn,
-            endpoint=f"{MONITOR_TYPE}/{serial_number}/cpu-utilization-trends",
-            params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            },
-            version=API_VERSION,
+            serial_number,
+            metric="cpu-utilization",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
         )
 
     @staticmethod
@@ -347,42 +410,19 @@ class MonitoringGateways:
         start_time=None,
         end_time=None,
         duration=None,
+        site_id=None,
+        return_raw_response=False,
     ):
-        """
-        Retrieve memory utilization trends for a gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/memory-utilization-trends`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string or seconds for relative queries.
-
-        Returns:
-            (dict|list): API response for memory-utilization-trends.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
-        validate_central_conn_and_serial(central_conn, serial_number)
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(
-                central_conn,
-                endpoint=f"{MONITOR_TYPE}/{serial_number}/memory-utilization-trends",
-                version=API_VERSION,
-            )
-
-        return execute_get(
+        """Retrieve memory utilization trends for a gateway."""
+        return MonitoringGateways.get_gateway_trends(
             central_conn,
-            endpoint=f"{MONITOR_TYPE}/{serial_number}/memory-utilization-trends",
-            params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            },
-            version=API_VERSION,
+            serial_number,
+            metric="memory-utilization",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
         )
 
     @staticmethod
@@ -392,63 +432,707 @@ class MonitoringGateways:
         start_time=None,
         end_time=None,
         duration=None,
+        site_id=None,
+        return_raw_response=False,
     ):
-        """
-        Retrieve WAN availability trends for a gateway.
-
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/wan-availability-trends`
-
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-            start_time (int, optional): Start time (epoch seconds) for range queries.
-            end_time (int, optional): End time (epoch seconds) for range queries.
-            duration (str|int, optional): Duration string or seconds for relative queries.
-
-        Returns:
-            (dict|list): API response for wan-availability-trends.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
-        validate_central_conn_and_serial(central_conn, serial_number)
-        if start_time is None and end_time is None and duration is None:
-            return execute_get(
-                central_conn,
-                endpoint=f"{MONITOR_TYPE}/{serial_number}/wan-availability-trends",
-                version=API_VERSION,
-            )
-
-        return execute_get(
+        """Retrieve WAN availability trends for a gateway."""
+        return MonitoringGateways.get_gateway_trends(
             central_conn,
-            endpoint=f"{MONITOR_TYPE}/{serial_number}/wan-availability-trends",
-            params={
-                "filter": generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            },
-            version=API_VERSION,
+            serial_number,
+            metric="wan-availability",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
         )
 
     @staticmethod
-    def get_tunnel_health_summary(central_conn, serial_number):
-        """
-        Retrieve LAN tunnels health summary for a gateway.
+    def get_gateway_vpn_availability(
+        central_conn,
+        serial_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve VPN availability trends for a gateway."""
+        return MonitoringGateways.get_gateway_trends(
+            central_conn,
+            serial_number,
+            metric="vpn-availability",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
 
-        This method makes an API call to the following endpoint - `GET network-monitoring/v1alpha1/gateways/{serial_number}/lan-tunnels-health-summary`
+    @staticmethod
+    def get_gateway_temperature_trends(
+        central_conn,
+        serial_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve hardware temperature trends for a gateway."""
+        return MonitoringGateways.get_gateway_trends(
+            central_conn,
+            serial_number,
+            metric="hardware-temperature",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
 
-        Args:
-            central_conn (NewCentralBase): Central connection object.
-            serial_number (str): Serial number of the gateway.
-
-        Returns:
-            (dict): API response for lan-tunnels-health-summary.
-
-        Raises:
-            ParameterError: If central_conn is None or serial_number is missing/invalid.
-        """
+    @staticmethod
+    def get_gateway_stats(
+        central_conn,
+        serial_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Collect CPU, memory, and WAN availability trends for a gateway."""
         validate_central_conn_and_serial(central_conn, serial_number)
-        path = f"{MONITOR_TYPE}/{serial_number}/current-routes"
-        return execute_get(central_conn, endpoint=path, version=API_VERSION)
 
+        raw_results = []
+        for metric in (
+            "cpu-utilization",
+            "memory-utilization",
+            "wan-availability",
+        ):
+            raw_results.append(
+                MonitoringGateways.get_gateway_trends(
+                    central_conn,
+                    serial_number,
+                    metric=metric,
+                    start_time=start_time,
+                    end_time=end_time,
+                    duration=duration,
+                    site_id=site_id,
+                    return_raw_response=True,
+                )
+            )
 
+        if return_raw_response:
+            return raw_results
+
+        data = {}
+        for response in raw_results:
+            if isinstance(response, dict):
+                data = clean_raw_trend_data(response, data=data)
+        return merged_dict_to_sorted_list(data)
+
+    @staticmethod
+    def get_latest_gateway_stats(central_conn, serial_number):
+        """Get the latest gateway statistics."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        stats = MonitoringGateways.get_gateway_stats(
+            central_conn,
+            serial_number,
+            duration="5m",
+        )
+        return stats[-1] if isinstance(stats, list) and stats else {}
+
+    @staticmethod
+    def get_gateway_port_trends(
+        central_conn,
+        serial_number,
+        port_number,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve trend data for a gateway port metric."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("port_number", port_number)
+        metric = normalize_metric(metric, PORT_TREND_METRICS)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
+        response = execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/ports/{port_number}/"
+                f"{PORT_TREND_METRICS[metric]}"
+            ),
+            params=params,
+        )
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_gateway_port_throughput_trends(
+        central_conn,
+        serial_number,
+        port_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_port_trends(
+            central_conn,
+            serial_number,
+            port_number,
+            metric="throughput",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_port_frames_trends(
+        central_conn,
+        serial_number,
+        port_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_port_trends(
+            central_conn,
+            serial_number,
+            port_number,
+            metric="frames",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_port_frames_errors_trends(
+        central_conn,
+        serial_number,
+        port_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_port_trends(
+            central_conn,
+            serial_number,
+            port_number,
+            metric="frames-errors",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_port_frames_packets_trends(
+        central_conn,
+        serial_number,
+        port_number,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_port_trends(
+            central_conn,
+            serial_number,
+            port_number,
+            metric="frames-packets",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_tunnel_trends(
+        central_conn,
+        serial_number,
+        tunnel_name,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve trend data for a gateway tunnel metric."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("tunnel_name", tunnel_name)
+        metric = normalize_metric(metric, TUNNEL_TREND_METRICS)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
+        response = execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/tunnels/{tunnel_name}/"
+                f"{TUNNEL_TREND_METRICS[metric]}"
+            ),
+            params=params
+        )
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_gateway_tunnel_throughput_trends(
+        central_conn,
+        serial_number,
+        tunnel_name,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_tunnel_trends(
+            central_conn,
+            serial_number,
+            tunnel_name,
+            metric="throughput",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_tunnel_status_trends(
+        central_conn,
+        serial_number,
+        tunnel_name,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_tunnel_trends(
+            central_conn,
+            serial_number,
+            tunnel_name,
+            metric="status",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_tunnel_dropped_packets_trends(
+        central_conn,
+        serial_number,
+        tunnel_name,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_tunnel_trends(
+            central_conn,
+            serial_number,
+            tunnel_name,
+            metric="dropped-packets",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_uplink_trends(
+        central_conn,
+        serial_number,
+        link_tag,
+        metric,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve trend data for a gateway uplink metric."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("link_tag", link_tag)
+        metric = normalize_metric(metric, UPLINK_TREND_METRICS)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
+        response = execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/uplinks/{link_tag}/"
+                f"{UPLINK_TREND_METRICS[metric]}"
+            ),
+            params=params
+        )
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_gateway_uplink_throughput_trends(
+        central_conn,
+        serial_number,
+        link_tag,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_uplink_trends(
+            central_conn,
+            serial_number,
+            link_tag,
+            metric="throughput",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_uplink_wan_compression_trends(
+        central_conn,
+        serial_number,
+        link_tag,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_uplink_trends(
+            central_conn,
+            serial_number,
+            link_tag,
+            metric="wan-compression",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_uplink_wan_availability_trends(
+        central_conn,
+        serial_number,
+        link_tag,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        return MonitoringGateways.get_gateway_uplink_trends(
+            central_conn,
+            serial_number,
+            link_tag,
+            metric="wan-availability",
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+            return_raw_response=return_raw_response,
+        )
+
+    @staticmethod
+    def get_gateway_uplink_vpn_availability_trends(
+        central_conn,
+        serial_number,
+        vlan_id,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve uplink VPN availability trends using VLAN identifier."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("vlan_id", vlan_id)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
+        response = execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/uplinks/{vlan_id}/"
+                "vpn-availability-trends"
+            ),
+            params=params
+        )
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_gateway_uplink_probes(
+        central_conn,
+        serial_number,
+        link_tag,
+        filter_str=None,
+        site_id=None,
+    ):
+        """Retrieve probe definitions for a gateway uplink."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("link_tag", link_tag)
+        validate_query_length("filter_str", filter_str)
+        validate_site_id(site_id)
+        return execute_get(
+            central_conn,
+            endpoint=f"{MONITOR_TYPE}/{serial_number}/uplinks/{link_tag}/probes",
+            params={
+                "filter": filter_str,
+                "site-id": site_id,
+            }
+        )
+
+    @staticmethod
+    def get_gateway_uplink_probe_performance_trends(
+        central_conn,
+        serial_number,
+        link_tag,
+        probe,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        site_id=None,
+        return_raw_response=False,
+    ):
+        """Retrieve performance trends for a gateway uplink probe."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        validate_required_value("link_tag", link_tag)
+        validate_required_value("probe", probe)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
+        response = execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/uplinks/{link_tag}/probes/{probe}/"
+                "performance-trends"
+            ),
+            params=params
+        )
+        return normalize_trend_response(response, return_raw_response)
+
+    @staticmethod
+    def get_gateway_tunnel_health_summary(
+        central_conn,
+        serial_number,
+        tunnel_type="lan",
+    ):
+        """Retrieve tunnel health summary for a gateway."""
+        validate_central_conn_and_serial(central_conn, serial_number)
+        normalized_tunnel_type = str(tunnel_type).lower()
+        tunnel_paths = {
+            "lan": "lan-tunnels-health-summary",
+            "wan": "wan-tunnels-health-summary",
+        }
+        if normalized_tunnel_type not in tunnel_paths:
+            raise ParameterError("tunnel_type must be either 'lan' or 'wan'")
+        return execute_get(
+            central_conn,
+            endpoint=(
+                f"{MONITOR_TYPE}/{serial_number}/"
+                f"{tunnel_paths[normalized_tunnel_type]}"
+            )
+        )
+
+    @staticmethod
+    def get_all_cluster_members(
+        central_conn,
+        cluster_name,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all cluster members, handling pagination."""
+        validate_required_value("cluster_name", cluster_name)
+        return get_all_pages(
+            MonitoringGateways.get_cluster_members,
+            limit=CLUSTER_LIMIT,
+            central_conn=central_conn,
+            cluster_name=cluster_name,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_cluster_members(
+        central_conn,
+        cluster_name,
+        filter_str=None,
+        sort=None,
+        limit=CLUSTER_LIMIT,
+        next_page=1,
+    ):
+        """Retrieve a single page of cluster members."""
+        validate_required_value("cluster_name", cluster_name)
+        validate_limit_and_next(limit, next_page, CLUSTER_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+        return execute_get(
+            central_conn,
+            endpoint=f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/members",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            }
+        )
+
+    @staticmethod
+    def get_all_cluster_tunnels(
+        central_conn,
+        cluster_name,
+        filter_str=None,
+        sort=None,
+    ):
+        """Retrieve all cluster tunnels, handling pagination."""
+        validate_required_value("cluster_name", cluster_name)
+        return get_all_pages(
+            MonitoringGateways.get_cluster_tunnels,
+            limit=CLUSTER_LIMIT,
+            central_conn=central_conn,
+            cluster_name=cluster_name,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_cluster_tunnels(
+        central_conn,
+        cluster_name,
+        filter_str=None,
+        sort=None,
+        limit=CLUSTER_LIMIT,
+        next_page=1,
+    ):
+        """Retrieve a single page of cluster tunnels."""
+        validate_required_value("cluster_name", cluster_name)
+        validate_limit_and_next(limit, next_page, CLUSTER_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+        return execute_get(
+            central_conn,
+            endpoint=f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/tunnels",
+            params={
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            }
+        )
+
+    @staticmethod
+    def get_cluster_vlan_mismatch(
+        central_conn,
+        cluster_name,
+        filter_str=None,
+    ):
+        """Retrieve VLAN mismatch details for a cluster."""
+        validate_required_value("cluster_name", cluster_name)
+        validate_query_length("filter_str", filter_str)
+        return execute_get(
+            central_conn,
+            endpoint=f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/vlan-mismatch",
+            params={"filter": filter_str}
+        )
+
+    @staticmethod
+    def get_cluster_connectivity_graph(central_conn, cluster_name):
+        """Retrieve connectivity graph details for a cluster."""
+        validate_required_value("cluster_name", cluster_name)
+        return execute_get(
+            central_conn,
+            endpoint=f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/connectivity-graph"
+        )
+
+    @staticmethod
+    def get_cluster_tunnel_summary(
+        central_conn,
+        cluster_name,
+        summary_type="health",
+    ):
+        """Retrieve cluster tunnel health or status summary."""
+        validate_required_value("cluster_name", cluster_name)
+        normalized_summary_type = str(summary_type).lower()
+        summary_paths = {
+            "health": "tunnels-health-summary",
+            "status": "tunnels-status-summary",
+        }
+        if normalized_summary_type not in summary_paths:
+            raise ParameterError("summary_type must be either 'health' or 'status'")
+        return execute_get(
+            central_conn,
+            endpoint=(
+                f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/"
+                f"{summary_paths[normalized_summary_type]}"
+            )
+        )
+
+    @staticmethod
+    def get_cluster_capacity_trends(
+        central_conn,
+        cluster_name,
+        serial_number=None,
+        start_time=None,
+        end_time=None,
+        duration=None,
+        return_raw_response=False,
+    ):
+        """Retrieve cluster capacity trends."""
+        validate_required_value("cluster_name", cluster_name)
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+        )
+        endpoint = f"{CLUSTER_MONITOR_TYPE}/{cluster_name}/capacity-trends"
+        if serial_number is not None:
+            validate_required_value("serial_number", serial_number)
+            endpoint = f"{endpoint}/{serial_number}"
+        response = execute_get(
+            central_conn,
+            endpoint=endpoint,
+            params=params
+        )
+        return normalize_trend_response(response, return_raw_response)

--- a/pycentral/new_monitoring/sites.py
+++ b/pycentral/new_monitoring/sites.py
@@ -1,10 +1,10 @@
 from ..utils.monitoring_utils import execute_get, simplified_site_resp
 from ..exceptions import ParameterError
+from .constants import SITE_LIMIT
 
 # Sites doesn't really abide by the same pattern as other monitor types
 # Should we keep?
 MONITOR_TYPE = "sites"
-SITE_LIMIT = 100
 
 
 class MonitoringSites:

--- a/pycentral/new_monitoring/switches.py
+++ b/pycentral/new_monitoring/switches.py
@@ -1,14 +1,15 @@
 from ..utils.monitoring_utils import (
+    build_trend_params,
     execute_get,
-    generate_timestamp_str,
+    get_all_pages,
+    normalize_trend_response,
     validate_central_conn_and_serial,
-    clean_switch_trend_data,
+    validate_limit_and_next,
+    validate_query_length,
 )
 from ..exceptions import ParameterError
+from .constants import SWITCH_LIMIT
 
-SWITCH_LIMIT = 1000
-# Maximum length for query parameters (filter_str, sort, search) used across methods
-MAX_QUERY_LEN = 256
 MONITOR_TYPE = "switches"
 
 
@@ -17,6 +18,9 @@ class MonitoringSwitches:
     def get_all_switches(central_conn, filter_str=None, sort=None):
         """
         Retrieve all switches, handling pagination.
+
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/switches`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
@@ -27,31 +31,22 @@ class MonitoringSwitches:
         Returns:
             (list[dict]): List of switch items.
         """
-        switches = []
-        total_switches = None
-        limit = SWITCH_LIMIT
-        next = 1
-        while True:
-            response = MonitoringSwitches.get_switches(
-                central_conn, filter_str=filter_str, sort=sort, limit=limit, next=next
-            )
-            if total_switches is None:
-                total_switches = response.get("total", 0)
-            switches.extend(response.get("items", []))
-            if len(switches) >= total_switches:
-                break
-            next = response.get("next")
-            if next is None:
-                break
-
-        return switches
+        return get_all_pages(
+            MonitoringSwitches.get_switches,
+            limit=SWITCH_LIMIT,
+            central_conn=central_conn,
+            filter_str=filter_str,
+            sort=sort,
+        )
 
     @staticmethod
     def get_switches(
-        central_conn, filter_str=None, sort=None, limit=SWITCH_LIMIT, next=1
+        central_conn, filter_str=None, sort=None, limit=SWITCH_LIMIT, next_page=1
     ):
         """
         Retrieve a single page of switches associated to a customer, based on the query parameters provided.
+
+        This method makes an API call to the following endpoint - `GET network-monitoring/v1/switches`
 
         Args:
             central_conn (NewCentralBase): Central connection object.
@@ -63,30 +58,23 @@ class MonitoringSwitches:
                 optionally followed by 'asc' or 'desc'. Max length 256.
                 Supported fields: siteId, model, status, deployment, serialNumber, deviceName.
             limit (int, optional): Maximum number of switches to return (0-1000, default is 1000).
-            next (int, optional): Pagination cursor for next page of resources (default is 1).
+            next_page (int, optional): Pagination cursor for next page of resources (default is 1).
 
         Returns:
             (dict): API response containing keys like 'items', 'total', and 'next'.
 
         Raises:
-            ParameterError: If limit exceeds 1000.
+            ParameterError: If limit exceeds 1000 or next_page is less than 1.
             ParameterError: If filter_str exceeds the maximum query length.
             ParameterError: If sort exceeds the maximum query length.
         """
-        if limit > SWITCH_LIMIT:
-            raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
-        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
-            )
-        if sort is not None and len(sort) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"sort cannot exceed {MAX_QUERY_LEN} characters"
-            )
+        validate_limit_and_next(limit, next_page, SWITCH_LIMIT)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
 
         params = {
             "limit": limit,
-            "next": next,
+            "next": next_page,
             "filter": filter_str,
             "sort": sort,
         }
@@ -224,18 +212,9 @@ class MonitoringSwitches:
         validate_central_conn_and_serial(central_conn, serial_number)
         if limit > SWITCH_LIMIT:
             raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
-        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
-            )
-        if search is not None and len(search) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"search cannot exceed {MAX_QUERY_LEN} characters"
-            )
-        if sort is not None and len(sort) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"sort cannot exceed {MAX_QUERY_LEN} characters"
-            )
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("search", search)
+        validate_query_length("sort", sort)
 
         params = {
             "limit": limit,
@@ -288,18 +267,9 @@ class MonitoringSwitches:
         validate_central_conn_and_serial(central_conn, serial_number)
         if limit > SWITCH_LIMIT:
             raise ParameterError(f"limit cannot exceed {SWITCH_LIMIT}")
-        if filter_str is not None and len(filter_str) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"filter_str cannot exceed {MAX_QUERY_LEN} characters"
-            )
-        if search is not None and len(search) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"search cannot exceed {MAX_QUERY_LEN} characters"
-            )
-        if sort is not None and len(sort) > MAX_QUERY_LEN:
-            raise ParameterError(
-                f"sort cannot exceed {MAX_QUERY_LEN} characters"
-            )
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("search", search)
+        validate_query_length("sort", sort)
 
         params = {
             "limit": limit,
@@ -343,26 +313,16 @@ class MonitoringSwitches:
         if not central_conn:
             raise ParameterError("central_conn is required")
 
-        filter_str = None
-        if start_time is not None or end_time is not None or duration is not None:
-            try:
-                filter_str = generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            except ValueError as e:
-                raise ParameterError(str(e)) from e
-
-        params = {
-            "site-id": site_id,
-            "filter": filter_str,
-        }
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
         path = f"{MONITOR_TYPE}/topn-interface-trends"
         response = execute_get(central_conn, endpoint=path, params=params)
 
-        if return_raw_response:
-            return response
-
-        return clean_switch_trend_data(response)
+        return normalize_trend_response(response, return_raw_response)
 
     @staticmethod
     def get_switch_interface_trends(
@@ -406,28 +366,18 @@ class MonitoringSwitches:
         """
         validate_central_conn_and_serial(central_conn, serial_number)
 
-        filter_str = None
-        if start_time is not None or end_time is not None or duration is not None:
-            try:
-                filter_str = generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            except ValueError as e:
-                raise ParameterError(str(e)) from e
-
-        params = {
-            "site-id": site_id,
-            "interface-id": interface_id,
-            "uplink": uplink,
-            "filter": filter_str,
-        }
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        ) or {}
+        params["interface-id"] = interface_id
+        params["uplink"] = uplink
         path = f"{MONITOR_TYPE}/{serial_number}/interface-trends"
         response = execute_get(central_conn, endpoint=path, params=params)
 
-        if return_raw_response:
-            return response
-
-        return clean_switch_trend_data(response)
+        return normalize_trend_response(response, return_raw_response)
 
     @staticmethod
     def get_switch_hardware_trends(
@@ -468,26 +418,16 @@ class MonitoringSwitches:
         """
         validate_central_conn_and_serial(central_conn, serial_number)
 
-        filter_str = None
-        if start_time is not None or end_time is not None or duration is not None:
-            try:
-                filter_str = generate_timestamp_str(
-                    start_time=start_time, end_time=end_time, duration=duration
-                )
-            except ValueError as e:
-                raise ParameterError(str(e)) from e
-
-        params = {
-            "site-id": site_id,
-            "filter": filter_str,
-        }
+        params = build_trend_params(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+            site_id=site_id,
+        )
         path = f"{MONITOR_TYPE}/{serial_number}/hardware-trends"
         response = execute_get(central_conn, endpoint=path, params=params)
 
-        if return_raw_response:
-            return response
-
-        return clean_switch_trend_data(response)
+        return normalize_trend_response(response, return_raw_response)
 
     @staticmethod
     def get_switch_interface_poe(central_conn, serial_number):

--- a/pycentral/new_monitoring/wlans.py
+++ b/pycentral/new_monitoring/wlans.py
@@ -1,0 +1,107 @@
+from ..utils.monitoring_utils import (
+    execute_get,
+    get_all_pages,
+    validate_limit_and_next,
+    validate_query_length,
+    validate_serial_query,
+    validate_site_id,
+)
+from .constants import WLAN_LIMIT
+
+
+class WLAN:
+    @staticmethod
+    def get_all_wlans(
+        central_conn,
+        site_id=None,
+        serial_number=None,
+        filter_str=None,
+        sort=None,
+    ):
+        """
+        Retrieve all WLANs associated to a customer, handling pagination.
+
+        This method retrieves all results by repeatedly calling the following endpoint -
+        `GET network-monitoring/v1/wlans`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            site_id (str, optional): Site identifier to filter WLANs.
+            serial_number (str, optional): Serial number of an AP to filter WLANs.
+            filter_str (str, optional): Optional filter expression for the WLAN list.
+            sort (str, optional): Optional sort expression for the WLAN list.
+
+        Returns:
+            (list[dict]): List of WLAN items.
+        """
+        return get_all_pages(
+            WLAN.get_wlans,
+            limit=WLAN_LIMIT,
+            central_conn=central_conn,
+            site_id=site_id,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+        )
+
+    @staticmethod
+    def get_wlans(
+        central_conn,
+        site_id=None,
+        serial_number=None,
+        filter_str=None,
+        sort=None,
+        limit=WLAN_LIMIT,
+        next_page=1,
+    ):
+        """
+        Retrieve a list of WLANs associated to a customer.
+
+        This method makes an API call to the following endpoint - `GET network-monitoring/v1/wlans`
+
+        Args:
+            central_conn (NewCentralBase): Central connection object.
+            site_id (str, optional): ID of the Site for which WLAN information is requested. Max length 128.
+            serial_number (str, optional): Serial number of an access point device. Max length 16.
+            filter_str (str, optional): OData Version 4.0 filter string (limited functionality). 
+                Supports only 'and' conjunction ('or' and 'not' are NOT supported). 
+                Supported field: band (operators: eq, in). Max length 256.
+            sort (str, optional): Comma separated list of sort expressions. Supported fields: 
+                wlanName, band, status, securityLevel, security, vlan, primaryUsage. Max length 256.
+            limit (int, optional): Maximum number of WLANs to return (0-1000, default is 1000).
+            next_page (int, optional): Pagination cursor for next page (default is 1).
+
+        Returns:
+            (dict): API response containing:
+                - items (list): List of WLAN dictionaries with fields like wlanName, primaryUsage,
+                    securityLevel, security, band, status, vlan, id, type.
+                - count (int): Number of WLANs in current response.
+                - total (int): Total number of WLANs matching the criteria.
+                - next (str|None): Pagination cursor for the next page.
+
+        Raises:
+            ParameterError: If limit exceeds 1000 or next_page is less than 1.
+            ParameterError: If site_id exceeds 128 characters.
+            ParameterError: If serial_number exceeds 16 characters.
+            ParameterError: If filter_str exceeds 256 characters.
+            ParameterError: If sort exceeds 256 characters.
+        """
+        validate_limit_and_next(limit, next_page, WLAN_LIMIT)
+        validate_site_id(site_id)
+        validate_serial_query(serial_number)
+        validate_query_length("filter_str", filter_str)
+        validate_query_length("sort", sort)
+
+        return execute_get(
+            central_conn,
+            endpoint="wlans",
+            params={
+                "site-id": site_id,
+                "serial-number": serial_number,
+                "filter": filter_str,
+                "sort": sort,
+                "limit": limit,
+                "next": next_page,
+            },
+        )
+   

--- a/pycentral/streaming/streaming.py
+++ b/pycentral/streaming/streaming.py
@@ -59,6 +59,9 @@ class Streaming:
         filters=None,
     ):
         self.central_conn = central_conn
+        # cache the commonly used app route and token key to simplify lookups
+        self.app_route = self.central_conn._app_routes["new_central"]
+        self.token_key = self.app_route["token_key"]
         if event not in SUPPORTED_EVENTS:
             raise ValueError(
                 f"Unsupported event: {event}. Supported events: {list(SUPPORTED_EVENTS.keys())}"

--- a/pycentral/streaming/streaming.py
+++ b/pycentral/streaming/streaming.py
@@ -1,13 +1,16 @@
 import ssl
+import threading
+import signal
+from urllib.parse import urlencode
+
 import websocket
+from google.protobuf.json_format import MessageToDict
+
 from .events.audit import audit_trail_pb2
 from .events.location import location_pb2
 from .events.location_analytics import location_analytics_pb2
 from .events.geofence import geofence_pb2
 from .events.event import event_pb2
-from google.protobuf.json_format import MessageToDict
-import threading
-import signal
 
 VERSION = "v1alpha1"
 # Central-mandated ping settings (not user-configurable)
@@ -25,7 +28,7 @@ SUPPORTED_EVENTS = {
 
 class Streaming:
     """
-    Minimal WebSocket streaming client for HPE Aruba Networking Central.
+    Minimal WebSocket streaming client for Central.
 
     Responsibilities:
         - Build the WSS URL for the selected streaming endpoint.
@@ -110,11 +113,8 @@ class Streaming:
         Returns:
             list[str]: Header strings ready for websocket.WebSocketApp.
         """
-        token = self.central_conn.token_info["new_central"]["access_token"]
-        headers = [f"Authorization: Bearer {token}"]
-        if self.filters:
-            headers.append(f"event-types: {self.filters}")
-        return headers
+        token = self.central_conn.token_info[self.token_key]["access_token"]
+        return [f"Authorization: Bearer {token}"]
 
     def _on_message(self, ws, message):
         """Handle incoming WebSocket messages.
@@ -164,7 +164,7 @@ class Streaming:
         if isinstance(error, websocket.WebSocketBadStatusException):
             if error.status_code == 401:
                 try:
-                    self.central_conn.handle_expired_token("new_central")
+                    self.central_conn._renew_token(self.token_key)
                     self.logger.info("Token refreshed. Will reconnect.")
                 except Exception as refresh_error:
                     self.logger.error(f"Token refresh failed: {refresh_error}")
@@ -208,17 +208,21 @@ class Streaming:
         """Build the WebSocket Secure (WSS) URL for the configured event.
 
         The URL is constructed using the Central base URL from the
-        connection object and the event-specific endpoint.
+        connection object and the event-specific endpoint. If filters
+        are configured, they are appended as the ``event-types`` query
+        parameter.
 
         Returns:
             str: Fully qualified WSS URL for the streaming endpoint.
         """
-        base_url = self.central_conn.token_info["new_central"][
-            "base_url"
-        ].rstrip("/")
+        base_url = self.app_route["base_url"].rstrip("/")
         # Strip any scheme so we can always prefix with wss://
         host = base_url.replace("https://", "", 1).replace("http://", "", 1)
-        return f"wss://{host}/network-services/{VERSION}/{self.endpoint}"
+        url = f"wss://{host}/network-services/{VERSION}/{self.endpoint}"
+        if self.filters:
+            query_filter = urlencode({"event-types": self.filters})
+            url = f"{url}?{query_filter}"
+        return url
 
     def stream(self, callback=None):
         """Start streaming messages for the configured event.
@@ -256,7 +260,7 @@ class Streaming:
                         on_message=self._on_message,
                     )
 
-                    self.logger.info(f"Connecting to {url}...")
+                    self.logger.info(f"Connecting to {url.split('?')[0]}...")
                     self.ws.run_forever(
                         sslopt={"cert_reqs": ssl.CERT_NONE},
                         ping_interval=_PING_INTERVAL,

--- a/pycentral/troubleshooting/troubleshooting.py
+++ b/pycentral/troubleshooting/troubleshooting.py
@@ -4827,7 +4827,7 @@ class Troubleshooting:
                 name optionally followed by a direction indicator 'asc' (ascending)
                 or 'desc' (descending). If direction is omitted, default is descending.
                 Supported field: timestamp. Max length 128.
-            next_cursor (int, optional): Specifies the pagination cursor for the next
+            next_cursor (int or str, optional): Specifies the pagination cursor for the next
                 page of resources. Minimum value is 1. Defaults to 1.
             limit (int, optional): Maximum number of events to be retrieved. Allowed
                 range is 1 to 1000. Defaults to 100.

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -303,7 +303,7 @@ def valid_url(url):
     Verify and return the URL in a valid format.
 
     If the URL is missing the https prefix, the function will prepend the prefix
-    after verifying that it's a valid base URL of an HPE Aruba Networking Central cluster.
+    after verifying that it's a valid base URL of an Central cluster.
 
     Args:
         url (str): Base URL for an HTTP request.

--- a/pycentral/utils/constants.py
+++ b/pycentral/utils/constants.py
@@ -7,7 +7,7 @@ This module contains constant values for API endpoints, cluster URLs,
 and configuration mappings used throughout the pycentral SDK.
 
 Attributes:
-    CLUSTER_BASE_URLS (dict[str, str]): Public HPE Aruba Networking Central cluster
+    CLUSTER_BASE_URLS (dict[str, str]): Public Central cluster
         names with their corresponding API Base URLs. You can update this
         dictionary to add your own private cluster details. You can learn more about Base URLs <a href="https://developer.arubanetworks.com/new-central/docs/getting-started-with-rest-apis#api-gateway-base-urls" target="_blank">here</a>.
 

--- a/pycentral/utils/monitoring_utils.py
+++ b/pycentral/utils/monitoring_utils.py
@@ -4,7 +4,9 @@ from pycentral.utils.url_utils import generate_url
 
 from ..exceptions import ParameterError
 import re
-
+MAX_SITE_ID_LEN = 128
+MAX_QUERY_LEN = 256
+MAX_SERIAL_LEN = 16
 
 DEFAULT_MAX_PERIOD_DAYS = 90
 
@@ -120,7 +122,7 @@ def generate_timestamp_str(
     return f"timestamp gt {start_time} and timestamp lt {end_time}"
 
 
-def execute_get(central_conn, endpoint, params={}, version="latest"):
+def execute_get(central_conn, endpoint, params=None, version="latest"):
     """Execute a GET request to the monitoring API.
 
     Args:
@@ -139,7 +141,7 @@ def execute_get(central_conn, endpoint, params={}, version="latest"):
     if not central_conn:
         raise ParameterError("central_conn(Central connection) is required")
 
-    if not endpoint or not isinstance(endpoint, str) and len(endpoint) == 0:
+    if not isinstance(endpoint, str) or not endpoint:
         raise ParameterError("endpoint is required and must be a string")
 
     if endpoint.startswith("/"):
@@ -147,7 +149,7 @@ def execute_get(central_conn, endpoint, params={}, version="latest"):
         endpoint = endpoint.lstrip("/")
 
     path = generate_url(endpoint, "monitoring", version)
-    resp = central_conn.command("GET", path, api_params=params)
+    resp = central_conn.command("GET", path, api_params=params or {})
 
     if resp["code"] != 200:
         raise Exception(
@@ -206,7 +208,7 @@ def _groups_to_dict(groups_list):
     return result
 
 
-def clean_switch_trend_data(raw_response):
+def _clean_switch_trend_data(raw_response):
     """Process switch trend responses into a normalized list.
 
     Handles all formats returned by the switch trend endpoints:
@@ -356,25 +358,6 @@ def _validate_mac_address(mac):
     return True
 
 
-def validate_device_serial(serial_number):
-    """
-    Validate device serial number.
-
-    Args:
-        serial_number (str): Device serial number to validate.
-
-    Raises:
-        ParameterError: If serial_number is missing or not a string.
-
-    Note:
-        Internal SDK function
-    """
-    if not isinstance(serial_number, str) or not serial_number:
-        raise ParameterError(
-            "serial_number is required and must be a string"
-        )
-
-
 def validate_central_conn_and_serial(central_conn, serial_number):
     """
     Validate central connection and device serial number.
@@ -395,3 +378,275 @@ def validate_central_conn_and_serial(central_conn, serial_number):
         raise ParameterError(
             "serial_number is required and must be a string"
         )
+
+def validate_site_id(site_id):
+    if site_id is not None and len(site_id) > MAX_SITE_ID_LEN:
+        raise ParameterError(
+            f"site_id cannot exceed {MAX_SITE_ID_LEN} characters"
+        )
+
+
+def validate_query_length(name, value, max_length=MAX_QUERY_LEN):
+    """Raise ParameterError if a query string parameter exceeds the allowed length.
+
+    Args:
+        name (str): Parameter name (used in error message).
+        value (str|None): Parameter value to check.
+        max_length (int, optional): Maximum allowed character length. Defaults to MAX_QUERY_LEN.
+
+    Raises:
+        ParameterError: If value is not None and exceeds max_length.
+    """
+    if value is not None and len(value) > max_length:
+        raise ParameterError(f"{name} cannot exceed {max_length} characters")
+
+
+def validate_limit_and_next(limit, next_page, max_limit, next_name="next_page"):
+    """Raise ParameterError if pagination parameters are out of range.
+
+    Args:
+        limit (int): Requested page size.
+        next_page (int): Page cursor/index (must be >= 1).
+        max_limit (int): Maximum allowed value for limit.
+        next_name (str, optional): Name of the next_page parameter for error messages.
+
+    Raises:
+        ParameterError: If limit exceeds max_limit or next_page is less than 1.
+    """
+    if limit > max_limit:
+        raise ParameterError(f"limit cannot exceed {max_limit}")
+    if next_page < 1:
+        raise ParameterError(f"{next_name} must be 1 or greater")
+
+
+def validate_required_value(name, value):
+    """Raise ParameterError if a required parameter is missing or empty.
+
+    Args:
+        name (str): Parameter name (used in error message).
+        value (Any): Parameter value to check.
+
+    Raises:
+        ParameterError: If value is None or an empty string.
+    """
+    if value is None or value == "":
+        raise ParameterError(f"{name} is required")
+
+
+def validate_serial_query(serial_number, max_len=MAX_SERIAL_LEN):
+    """Raise ParameterError if an optional serial_number query parameter exceeds max_len.
+
+    Args:
+        serial_number (str|None): Serial number to validate. Skipped if None.
+        max_len (int, optional): Maximum allowed length. Defaults to MAX_SERIAL_LEN.
+
+    Raises:
+        ParameterError: If serial_number is not None and exceeds max_len.
+    """
+    if serial_number is not None and len(serial_number) > max_len:
+        raise ParameterError(f"serial_number cannot exceed {max_len} characters")
+
+
+def normalize_metric(metric, allowed_metrics, name="metric"):
+    """Validate and normalize a metric string against a set of allowed values.
+
+    Args:
+        metric (str): Metric name provided by the caller.
+        allowed_metrics (dict|set): Collection of allowed metric names (lowercase).
+        name (str, optional): Parameter name for error messages. Defaults to 'metric'.
+
+    Returns:
+        (str): Normalized (stripped, lowercased) metric name.
+
+    Raises:
+        ParameterError: If metric is not a non-empty string or is not in allowed_metrics.
+    """
+    if not isinstance(metric, str) or not metric:
+        raise ParameterError(f"{name} is required and must be a string")
+    normalized = metric.strip().lower()
+    if normalized not in allowed_metrics:
+        supported = ", ".join(sorted(allowed_metrics))
+        raise ParameterError(
+            f"Unsupported {name} '{metric}'. Supported values: {supported}"
+        )
+    return normalized
+
+
+def build_trend_params(
+    start_time=None,
+    end_time=None,
+    duration=None,
+    site_id=None,
+    extra_params=None,
+):
+    """Build a query-parameter dict for trend endpoints.
+
+    Validates site_id, merges extra_params, and generates a timestamp filter string
+    when any time argument is provided.
+
+    Args:
+        start_time (int|str, optional): Start time (epoch seconds or RFC3339).
+        end_time (int|str, optional): End time (epoch seconds or RFC3339).
+        duration (str|int, optional): Duration string (e.g. '3h') or seconds.
+        site_id (str, optional): Site identifier; validated against MAX_SITE_ID_LEN.
+        extra_params (dict, optional): Additional parameters to merge into the result.
+
+    Returns:
+        (dict|None): Parameter dict, or None if no parameters are set.
+
+    Raises:
+        ParameterError: If site_id is too long or timestamp arguments are invalid.
+    """
+    params = {}
+    if site_id is not None:
+        validate_site_id(site_id)
+        params["site-id"] = site_id
+    if extra_params:
+        params.update(extra_params)
+    if start_time is None and end_time is None and duration is None:
+        return params
+    try:
+        params["filter"] = generate_timestamp_str(
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
+        )
+    except ValueError as e:
+        raise ParameterError(str(e)) from e
+    return params
+
+
+def normalize_trend_response(response, return_raw_response=False):
+    """Normalize a raw trend API response from any device type.
+
+    Dispatches to the appropriate cleaner based on the response shape:
+    - Switch responses are wrapped in a ``"response"`` key and are handled
+      by ``_clean_switch_trend_data``.
+    - AP/gateway responses use a ``"graph"`` key and are handled by
+      ``clean_raw_trend_data``.
+    - Some gateway endpoints wrap the single trend object in a list; such
+      single-element lists are unwrapped to a dict before processing.
+
+    If return_raw_response is True the response is returned as-is (after any
+    single-element list unwrapping so callers always receive a dict).
+
+    Args:
+        response (dict|list): Raw API response.
+        return_raw_response (bool, optional): Return raw payload when True.
+
+    Returns:
+        (dict|list): Raw response or normalized sorted list of trend samples.
+    """
+    # Some gateway trend endpoints return their result wrapped in a list
+    # (one item per metric series / sensor).  Unwrap single-element lists so
+    # downstream logic treats them as a plain dict; aggregate multi-element
+    # lists by merging all series into a single timeline.
+    if isinstance(response, list):
+        if len(response) == 1 and isinstance(response[0], dict):
+            response = response[0]
+        else:
+            # Multi-series list (e.g. hardware-temperature with several sensors).
+            if return_raw_response:
+                return response
+            data = {}
+            for item in response:
+                if isinstance(item, dict):
+                    data = clean_raw_trend_data(item, data=data)
+            return merged_dict_to_sorted_list(data)
+
+    if return_raw_response:
+        return response
+    if not isinstance(response, dict):
+        return response
+    if "response" in response:
+        return _clean_switch_trend_data(response)
+    data = clean_raw_trend_data(response)
+    return merged_dict_to_sorted_list(data)
+
+
+def execute_trend_request(
+    central_conn,
+    base_path,
+    serial_number,
+    metric,
+    metric_map,
+    resource_path=None,
+    start_time=None,
+    end_time=None,
+    duration=None,
+    site_id=None,
+    extra_params=None,
+    return_raw_response=False,
+):
+    """Execute a trend API request for a monitoring resource.
+
+    Args:
+        central_conn (NewCentralBase): Central connection object.
+        base_path (str): Base endpoint path (e.g. 'aps', 'gateways').
+        serial_number (str): Device serial number.
+        metric (str): Metric name to retrieve.
+        metric_map (dict): Mapping of metric names to endpoint path segments.
+        resource_path (str, optional): Sub-resource path segment (e.g. 'ports/1').
+        start_time (int|str, optional): Start time for range queries.
+        end_time (int|str, optional): End time for range queries.
+        duration (str, optional): Duration string (e.g. '3h').
+        site_id (str, optional): Site identifier.
+        extra_params (dict, optional): Additional query parameters.
+        return_raw_response (bool, optional): Return raw API payload when True.
+
+    Returns:
+        (dict|list): Raw response or normalized trend samples.
+    """
+    validate_central_conn_and_serial(central_conn, serial_number)
+    metric = normalize_metric(metric, metric_map)
+    params = build_trend_params(
+        start_time=start_time,
+        end_time=end_time,
+        duration=duration,
+        site_id=site_id,
+        extra_params=extra_params,
+    )
+    path = f"{base_path}/{serial_number}"
+    if resource_path:
+        path = f"{path}/{resource_path}"
+    path = f"{path}/{metric_map[metric]}"
+    response = execute_get(central_conn, endpoint=path, params=params)
+    return normalize_trend_response(response, return_raw_response)
+
+
+def get_all_pages(method, limit, next_arg_name="next_page", **kwargs):
+    """Fetch all pages from a paginated monitoring API method.
+
+    Calls *method* repeatedly, passing the current page cursor via the keyword
+    argument named *next_arg_name*, until all items have been retrieved.
+
+    Args:
+        method (callable): Single-page fetch method.  Must accept ``limit`` and
+            the keyword named by *next_arg_name*, plus any additional **kwargs.
+        limit (int): Page size to request on each call.
+        next_arg_name (str, optional): Name of the pagination cursor parameter.
+            Defaults to 'next_page'.
+        **kwargs (Any): Additional keyword arguments forwarded to *method* on every call.
+
+    Returns:
+        (list[dict]): Aggregated list of all items across all pages.
+    """
+    items = []
+    total = None
+    next_page = 1
+
+    while True:
+        response = method(limit=limit, **{next_arg_name: next_page}, **kwargs)
+        if total is None:
+            total = response.get("total", 0)
+
+        items.extend(response.get("items", []))
+        if len(items) >= total:
+            break
+
+        next_value = response.get("next")
+        if next_value is None:
+            break
+        next_page = int(next_value)
+
+    return items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pycentral"
 dynamic = ["version"]
-description = "HPE Aruba Networking Central Python Package"
+description = "Central Python Package"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
-authors = [{ name = "aruba-automation", email = "aruba-automation@hpe.com" }]
+authors = [{ name = "hpe-networking-automation", email = "networking-automation@hpe.com" }]
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This release significantly expands the monitoring module coverage for APs, Gateways, and WLANs, adds 429 rate-limit retry handling, fixes streaming WebSocket client issues, and updates product branding across the SDK.

### New Features

- **Expanded AP Monitoring Module**
  - Added fleet-level retrieval methods: `get_all_radios`, `get_radios`, `get_all_bssids`, `get_bssids`, `get_all_swarms`, `get_swarms`, `get_swarm_details`
  - Added per-AP sub-resource methods: `get_ap_radios`, `get_ap_ports`, `get_all_ap_tunnels`, `get_ap_tunnels`, `get_ap_tunnel_details`, `get_ap_wlans`
  - Added trend endpoints: `get_ap_trends` (throughput, CPU, memory, power consumption), `get_ap_radio_trends` (throughput, channel utilization/quality, noise floor, frames), `get_ap_port_trends` (throughput, frames, CRC, collisions), `get_ap_tunnel_trends` (throughput, packet loss, MOS, jitter, latency)
- **Expanded Gateway Monitoring Module**
  - Added sub-resource methods: `get_all_gateway_ports`, `get_gateway_ports`, `get_gateway_port_details`, `get_all_gateway_vlans`, `get_gateway_vlans`, `get_gateway_vlan_details`, `get_all_gateway_tunnels`, `get_gateway_tunnels`, `get_gateway_tunnel_details`, `get_gateway_uplinks`, `get_gateway_uplink_details`, `get_all_gateway_dhcp_pools`, `get_gateway_dhcp_pools`, `get_all_gateway_dhcp_clients`, `get_gateway_dhcp_clients`
  - Added trend endpoints: `get_gateway_trends` (CPU, memory, WAN/VPN availability, hardware temperature), `get_gateway_port_trends` (throughput, frames, errors, packets), `get_gateway_tunnel_trends` (throughput, status, dropped packets), `get_gateway_uplink_trends` (throughput, WAN compression, WAN availability)
  - Added uplink probe methods: `get_gateway_uplink_probes`, `get_gateway_uplink_probe_performance_trends`, `get_gateway_uplink_vpn_availability_trends`
  - Added tunnel health: `get_gateway_tunnel_health_summary` (LAN/WAN)
  - Added cluster methods: `get_all_cluster_members`, `get_cluster_members`, `get_all_cluster_tunnels`, `get_cluster_tunnels`, `get_cluster_vlan_mismatch`, `get_cluster_connectivity_graph`, `get_cluster_tunnel_summary`, `get_cluster_capacity_trends`
- **WLAN Monitoring Module**
  - Added `WLAN` class with `get_all_wlans` and `get_wlans` methods supporting site_id, serial_number, filter, and sort parameters
- **429 Rate-Limit Retry**
  - `NewCentralBase.command()` now retries once after a 1-second pause when a 429 (Too Many Requests) response is received; logs an error and exits if the second attempt also fails

### Bug Fixes

- **Streaming WebSocket Client**
  - Event-type filters are now sent as URL query parameters instead of custom headers, fixing filter delivery to the server
  - Token refresh uses internal `_renew_token()` instead of deprecated `handle_expired_token()`
  - Cached `app_route` and `token_key` for correct internal lookups
  - Query parameters are stripped from connection log messages for readability

### Improvements

- **Shared Monitoring Utilities**
  - Added `get_all_pages` — generic pagination helper that replaces per-module while loops
  - Added `execute_trend_request` and `normalize_trend_response` — unified trend endpoint execution and response normalization
  - Added validation helpers: `validate_site_id`, `validate_query_length`, `validate_limit_and_next`, `validate_required_value`, `validate_serial_query`, `normalize_metric`, `build_trend_params`
  - Fixed `execute_get` default params (mutable default argument) and endpoint validation logic
  - Renamed `clean_switch_trend_data` → `_clean_switch_trend_data` (internal)
- **Constants Consolidation**
  - Extracted all pagination limits (AP_LIMIT, GATEWAY_LIMIT, SWITCH_LIMIT, etc.) into `pycentral/new_monitoring/constants.py`
- **Branding Update**
  - Shortened "HPE Aruba Networking Central" references to "Central" across documentation, docstrings, and project metadata
- Switches module refactored to use shared `get_all_pages`, `build_trend_params`, and validation utilities
- Updated monitoring API reference documentation with endpoint tables for APs, Gateways, and WLANs
- Fixed `next_cursor` type annotation in troubleshooting docstring (`int` → `int or str`)