### PR TITLE
v2.0a21

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,15 @@
+# 2.0a21
+
+This release contains minor bug fixes to align with actual API response values for device personas.
+
+### Bug Fixes
+
+- **Device Persona Handling**
+  - Corrected the persona key for Campus Access Points in `SUPPORTED_CONFIG_PERSONAS` from `"Campus AP"` to `"Campus Access Point"` to match the value returned by the Central API
+  - Added a warning log when a device's `device_function` value is not a recognised persona (and is not `'-'`), rather than silently skipping `config_persona` assignment
+
+Full Changelog: [v2.0a20...v2.0a21](https://github.com/aruba/pycentral/compare/v2.0a20...v2.0a21)
+
 # 2.0a20
 
 This release significantly expands the monitoring module coverage for APs, Gateways, and WLANs, adds 429 rate-limit retry handling, fixes streaming WebSocket client issues, and updates product branding across the SDK.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Today, there are two versions of PyCentral, each designed for different versions
 | Version                                                        | Supports                                                                                       | Notes                        |
 | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- | :--------------------------- |
 | [v1](https://pypi.org/project/pycentral/)                      | Classic Central                                                 | Legacy Version               |
-| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a10/) | Central( or new Central), GLP, Classic Central | Backwards compatible with v1 |
+| [v2(pre-release)](https://pypi.org/project/pycentral/2.0a21/) | Central( or new Central), GLP, Classic Central | Backwards compatible with v1 |
 
 ## Quick Example
 

--- a/pycentral/__init__.py
+++ b/pycentral/__init__.py
@@ -1,7 +1,7 @@
 # (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 # MIT License
 
-__version__ = "2.0a20"
+__version__ = "2.0a21"
 
 from .base import NewCentralBase
 from .msp import MSPBase

--- a/pycentral/scopes/device.py
+++ b/pycentral/scopes/device.py
@@ -195,6 +195,12 @@ class Device(ScopeBase):
             and device_function in SUPPORTED_CONFIG_PERSONAS
         ):
             self.config_persona = SUPPORTED_CONFIG_PERSONAS[device_function]
+        elif device_function not in SUPPORTED_CONFIG_PERSONAS and device_function != '-':
+            self.central_conn.logger.warning(
+                f"Device function '{device_function}' is not a supported "
+                f"persona. 'config_persona' will not be set for device "
+                f"{self.get_serial()}."
+            )
 
     def __rename_keys(self, api_dict, api_attribute_mapping):
         """Renames the keys of the attributes from the API response.

--- a/pycentral/utils/constants.py
+++ b/pycentral/utils/constants.py
@@ -42,7 +42,7 @@ CLUSTER_BASE_URLS = {
 }
 
 SUPPORTED_CONFIG_PERSONAS = {
-    "Campus AP": "CAMPUS_AP",
+    "Campus Access Point": "CAMPUS_AP",
     "Micro Branch AP": "MICROBRANCH_AP",
     "Access Switch": "ACCESS_SWITCH",
     "Core Switch": "CORE_SWITCH",


### PR DESCRIPTION
This release contains minor bug fixes to align with actual API response values for device personas.

### Bug Fixes

- **Device Persona Handling**
  - Corrected the persona key for Campus Access Points in `SUPPORTED_CONFIG_PERSONAS` from `"Campus AP"` to `"Campus Access Point"` to match the value returned by the Central API
  - Added a warning log when a device's `device_function` value is not a recognised persona (and is not `'-'`), rather than silently skipping `config_persona` assignment