### PR TITLE
feat: allow users to supply custom token_endpoint for token creation

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -36,6 +36,7 @@ PyCentral also supports a **unified credential** model. Instead of providing sep
 | `workspace_id` | Yes | GLP workspace ID |
 | `base_url` or `cluster_name` | Only for New Central calls | Identifies the Central API gateway. Omit if you only need GLP APIs |
 | `access_token` | No | Pre-existing token; if omitted the SDK generates one automatically |
+| `token_endpoint` | No | Custom OAuth token URL. Overrides the default token endpoint for both token creation and automatic renewal. **Central On-Prem (non-MSP) only** — use this when your deployment's token endpoint differs from the standard GLP or Central OAuth URL |
 
 ### Configuration Examples
 
@@ -66,6 +67,22 @@ token_info = {
 
 This enables GLP APIs only. Add `base_url` or `cluster_name` to also enable New Central APIs.
 
+**Unified — Central On-Prem with custom token endpoint** _(Central On-Prem only)_
+
+The optional `token_endpoint` field overrides the default GLP OAuth token URL used for both token creation and automatic renewal. Only relevant for **Central On-Prem (non-MSP) instances** where the token endpoint differs from the standard GLP OAuth URL.
+
+```python
+token_info = {
+    "unified": {
+        "client_id": "<glp-client-id>",
+        "client_secret": "<glp-client-secret>",
+        "workspace_id": "<workspace-id>",
+        "base_url": "https://<on-prem-central-host>",
+        "token_endpoint": "https://<on-prem-central-host>/oauth2/token"
+    }
+}
+```
+
 ## New Central
 
 **Base URL or Cluster Name (Choose one)**
@@ -83,6 +100,21 @@ Identifies your Central Account's API gateway. Both options function identically
     The SDK automatically generates new tokens when they expire, so you don't have to manage them manually. Learn how to create your credentials [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#create-client-credentials).
 - Access Token  
     Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#generate-access-token). **(Tokens expire in 2 hours)**
+
+**Custom Token Endpoint** _(Central On-Prem only)_:
+
+The optional `token_endpoint` field overrides the default OAuth token URL used for both token creation and automatic renewal. This is only relevant for **Central On-Prem (non-MSP) instances** where the token endpoint differs from the standard Central OAuth URL.
+
+```python
+token_info = {
+    "new_central": {
+        "client_id": "<client-id>",
+        "client_secret": "<client-secret>",
+        "base_url": "https://<on-prem-central-host>",
+        "token_endpoint": "https://<on-prem-central-host>/oauth2/token"
+    }
+}
+```
 
 ## GLP
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -84,7 +84,7 @@ Identifies your Central Account's API gateway. Both options function identically
 - Access Token  
     Manually, retrieve an access token. Learn how to retreive an access token [here](https://developer.arubanetworks.com/new-central/docs/generating-and-managing-access-tokens#generate-access-token). **(Tokens expire in 2 hours)**
 
-**Custom Token Endpoint** _(Central On-Prem only)_:
+## Central On-Prem
 
 For Central On-Prem deployments whose OAuth issuer differs from the standard GLP OAuth issuer, set `token_endpoint` to the complete token URL. The SDK uses it for initial token creation and automatic renewal. `base_url` remains the Central API URL for the On-Prem account. **This option is supported only under `new_central`.**
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -36,7 +36,6 @@ PyCentral also supports a **unified credential** model. Instead of providing sep
 | `workspace_id` | Yes | GLP workspace ID |
 | `base_url` or `cluster_name` | Only for New Central calls | Identifies the Central API gateway. Omit if you only need GLP APIs |
 | `access_token` | No | Pre-existing token; if omitted the SDK generates one automatically |
-| `token_endpoint` | No | Custom OAuth token URL. Overrides the default token endpoint for both token creation and automatic renewal. **Central On-Prem (non-MSP) only** — use this when your deployment's token endpoint differs from the standard GLP or Central OAuth URL |
 
 ### Configuration Examples
 
@@ -67,22 +66,6 @@ token_info = {
 
 This enables GLP APIs only. Add `base_url` or `cluster_name` to also enable New Central APIs.
 
-**Unified — Central On-Prem with custom token endpoint** _(Central On-Prem only)_
-
-The optional `token_endpoint` field overrides the default GLP OAuth token URL used for both token creation and automatic renewal. Only relevant for **Central On-Prem (non-MSP) instances** where the token endpoint differs from the standard GLP OAuth URL.
-
-```python
-token_info = {
-    "unified": {
-        "client_id": "<glp-client-id>",
-        "client_secret": "<glp-client-secret>",
-        "workspace_id": "<workspace-id>",
-        "base_url": "https://<on-prem-central-host>",
-        "token_endpoint": "https://<on-prem-central-host>/oauth2/token"
-    }
-}
-```
-
 ## New Central
 
 **Base URL or Cluster Name (Choose one)**
@@ -103,15 +86,15 @@ Identifies your Central Account's API gateway. Both options function identically
 
 **Custom Token Endpoint** _(Central On-Prem only)_:
 
-The optional `token_endpoint` field overrides the default OAuth token URL used for both token creation and automatic renewal. This is only relevant for **Central On-Prem (non-MSP) instances** where the token endpoint differs from the standard Central OAuth URL.
+For Central On-Prem deployments whose OAuth issuer differs from the standard GLP OAuth issuer, set `token_endpoint` to the complete token URL. The SDK uses it for initial token creation and automatic renewal. `base_url` remains the Central API URL for the On-Prem account. **This option is supported only under `new_central`.**
 
 ```python
 token_info = {
     "new_central": {
         "client_id": "<client-id>",
         "client_secret": "<client-secret>",
-        "base_url": "https://<on-prem-central-host>",
-        "token_endpoint": "https://<on-prem-central-host>/oauth2/token"
+        "base_url": "https://<on-prem-central-api-host>",
+        "token_endpoint": "http://<on-prem-token-issuer>/oauth2/token"
     }
 }
 ```

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -22,7 +22,7 @@ NEW_CENTRAL_C_DEFAULT_ARGS = {
     "client_id": None,
     "client_secret": None,
     "access_token": None,
-    "token_url": None,
+    "token_endpoint": None,
 }
 UNIFIED_DEFAULT_ARGS = {
     "client_id": None,
@@ -31,7 +31,7 @@ UNIFIED_DEFAULT_ARGS = {
     "glp_base_url": None,
     "base_url": None,
     "access_token": None,
-    "token_url": None,
+    "token_endpoint": None,
 }
 
 APP_TOKEN_CREATION_REQUIRED_KEYS = {
@@ -67,7 +67,7 @@ def new_parse_input_args(token_info):
         access token expires. Pass `base_url` or `cluster_name` under
         `unified` to also enable Central API calls.
 
-        An optional `token_url` key can be provided under any app to override
+        An optional `token_endpoint` key can be provided under any app to override
         the default OAuth token endpoint used for token creation and refresh.
     """
     token_info = load_token_info(token_info)
@@ -104,8 +104,8 @@ def new_parse_input_args(token_info):
         unified.pop("cluster_name", None)
 
         # Precompute token URL for token creation/refresh
-        if unified.get("token_url"):
-            unified["_token_url"] = valid_url(unified["token_url"])
+        if unified.get("token_endpoint"):
+            unified["_token_url"] = valid_url(unified["token_endpoint"])
         elif unified.get("workspace_id"):
             unified["_token_url"] = (
                 f"{AUTHENTICATION['OAUTH_GLOBAL']}/{unified['workspace_id']}/token"
@@ -122,8 +122,8 @@ def new_parse_input_args(token_info):
 
             app_token_info["base_url"] = _resolve_base_url(app, app_token_info)
             _validate_token_creation_keys(app, app_token_info)
-            if app_token_info.get("token_url"):
-                app_token_info["_token_url"] = valid_url(app_token_info["token_url"])
+            if app_token_info.get("token_endpoint"):
+                app_token_info["_token_url"] = valid_url(app_token_info["token_endpoint"])
             else:
                 app_token_info["_token_url"] = AUTHENTICATION["OAUTH"]
             apps_token_info[app] = {**NEW_CENTRAL_C_DEFAULT_ARGS, **app_token_info}

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -22,6 +22,7 @@ NEW_CENTRAL_C_DEFAULT_ARGS = {
     "client_id": None,
     "client_secret": None,
     "access_token": None,
+    "token_url": None,
 }
 UNIFIED_DEFAULT_ARGS = {
     "client_id": None,
@@ -30,6 +31,7 @@ UNIFIED_DEFAULT_ARGS = {
     "glp_base_url": None,
     "base_url": None,
     "access_token": None,
+    "token_url": None,
 }
 
 APP_TOKEN_CREATION_REQUIRED_KEYS = {
@@ -64,6 +66,9 @@ def new_parse_input_args(token_info):
         client credentials are still required for token refresh when the
         access token expires. Pass `base_url` or `cluster_name` under
         `unified` to also enable Central API calls.
+
+        An optional `token_url` key can be provided under any app to override
+        the default OAuth token endpoint used for token creation and refresh.
     """
     token_info = load_token_info(token_info)
 
@@ -99,7 +104,9 @@ def new_parse_input_args(token_info):
         unified.pop("cluster_name", None)
 
         # Precompute token URL for token creation/refresh
-        if unified.get("workspace_id"):
+        if unified.get("token_url"):
+            unified["_token_url"] = valid_url(unified["token_url"])
+        elif unified.get("workspace_id"):
             unified["_token_url"] = (
                 f"{AUTHENTICATION['OAUTH_GLOBAL']}/{unified['workspace_id']}/token"
             )
@@ -115,7 +122,10 @@ def new_parse_input_args(token_info):
 
             app_token_info["base_url"] = _resolve_base_url(app, app_token_info)
             _validate_token_creation_keys(app, app_token_info)
-            app_token_info["_token_url"] = AUTHENTICATION["OAUTH"]
+            if app_token_info.get("token_url"):
+                app_token_info["_token_url"] = valid_url(app_token_info["token_url"])
+            else:
+                app_token_info["_token_url"] = AUTHENTICATION["OAUTH"]
             apps_token_info[app] = {**NEW_CENTRAL_C_DEFAULT_ARGS, **app_token_info}
 
     return apps_token_info

--- a/pycentral/utils/base_utils.py
+++ b/pycentral/utils/base_utils.py
@@ -31,7 +31,6 @@ UNIFIED_DEFAULT_ARGS = {
     "glp_base_url": None,
     "base_url": None,
     "access_token": None,
-    "token_endpoint": None,
 }
 
 APP_TOKEN_CREATION_REQUIRED_KEYS = {
@@ -67,8 +66,9 @@ def new_parse_input_args(token_info):
         access token expires. Pass `base_url` or `cluster_name` under
         `unified` to also enable Central API calls.
 
-        An optional `token_endpoint` key can be provided under any app to override
-        the default OAuth token endpoint used for token creation and refresh.
+        An optional `token_endpoint` key can be provided under `new_central`
+        to override the default OAuth token endpoint used for token creation
+        and refresh in Central On-Prem deployments.
     """
     token_info = load_token_info(token_info)
 
@@ -92,6 +92,11 @@ def new_parse_input_args(token_info):
             )
 
         unified = dict(token_info["unified"])
+        if "token_endpoint" in unified:
+            raise ValueError(
+                "'token_endpoint' is supported only for 'new_central' "
+                "Central On-Prem credentials."
+            )
 
         # GLP is always the primary endpoint
         unified["glp_base_url"] = valid_url(
@@ -104,12 +109,9 @@ def new_parse_input_args(token_info):
         unified.pop("cluster_name", None)
 
         # Precompute token URL for token creation/refresh
-        if unified.get("token_endpoint"):
-            unified["_token_url"] = valid_url(unified["token_endpoint"])
-        elif unified.get("workspace_id"):
-            unified["_token_url"] = (
-                f"{AUTHENTICATION['OAUTH_GLOBAL']}/{unified['workspace_id']}/token"
-            )
+        unified["_token_url"] = (
+            f"{AUTHENTICATION['OAUTH_GLOBAL']}/{unified['workspace_id']}/token"
+        )
 
         apps_token_info["unified"] = {**UNIFIED_DEFAULT_ARGS, **unified}
 
@@ -119,10 +121,15 @@ def new_parse_input_args(token_info):
                 raise ValueError(
                     f"Unknown app name '{app}' provided. Supported apps: {', '.join(SUPPORTED_APPS)}"
                 )
+            if app != "new_central" and "token_endpoint" in app_token_info:
+                raise ValueError(
+                    "'token_endpoint' is supported only for 'new_central' "
+                    "Central On-Prem credentials."
+                )
 
             app_token_info["base_url"] = _resolve_base_url(app, app_token_info)
             _validate_token_creation_keys(app, app_token_info)
-            if app_token_info.get("token_endpoint"):
+            if app == "new_central" and "token_endpoint" in app_token_info:
                 app_token_info["_token_url"] = valid_url(app_token_info["token_endpoint"])
             else:
                 app_token_info["_token_url"] = AUTHENTICATION["OAUTH"]


### PR DESCRIPTION
In certain Aruba Central deployments, likes of OnPrem and internal QA clusters, token creation fails as it reaches the wrong token endpoint.

Allow users to supply a custom `token_endpoint` to override the default OAuth token endpoint used for token creation and refresh.